### PR TITLE
Prevent reuse of addresses

### DIFF
--- a/arb_os/accounts.mini
+++ b/arb_os/accounts.mini
@@ -107,6 +107,10 @@ public func account_isEmpty(acct: Account) -> bool {
     return (acct.nextSeqNum == 0) && (acct.ethBalance == 0) && (acct.contractInfo == None<AccountContractInfo>);
 }
 
+public func account_isContract(acct: Account) -> bool {
+    return (acct.contractInfo != None<AccountContractInfo>);
+}
+
 public func account_checkAndIncrSeqNum(
     account: Account, 
     seqNumRecvd: uint

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -18,6 +18,8 @@ use accounts::accountStore_transferEthBalance;
 use accounts::accountStore_createAccountFromEvmCode;
 use accounts::account_checkAndIncrSeqNum;
 use accounts::account_fetchAndIncrSeqNum;
+use accounts::account_isContract;
+
 use accounts::account_incrSeqNum;
 use accounts::account_getNextSeqNum;
 use accounts::account_addToEthBalance;
@@ -223,12 +225,18 @@ public impure func handleL2Request(
             };
         }
 
-        initEvmCallStackForConstructor(
-            codeBytes,
-            evmJumpTable,
-            codept,
-            request
-        );  // should never return
+        if (account_isContract(accountStore_get(getGlobalAccountStore(), request.calleeAddr))) {
+            // there's already an account at that address, revert the call
+            emitTxReceipt(request.incomingRequest, 7, None<ByteArray>, None<EvmLogs>, None<GasUsage>);
+            return Some(());
+        } else {
+            initEvmCallStackForConstructor(
+                codeBytes,
+                evmJumpTable,
+                codept,
+                request
+            );  // should never return
+        }
     } else {
         // this is a non-constructor call
         let callKind = 0;

--- a/arb_os/output.mini
+++ b/arb_os/output.mini
@@ -169,6 +169,7 @@ impure func update_txReceiptsForBlock(
 //    4    insufficient funds for tx payment
 //    5    bad sequence number
 //    6    message format error
+//    7    tried to deploy at address that is already in use
 //    255  unknown error
 public impure func emitTxReceipt(
     l1message: IncomingRequest,

--- a/src/evm/benchmarks.rs
+++ b/src/evm/benchmarks.rs
@@ -74,7 +74,7 @@ pub fn benchmark_add(iterations: u64, log_to: &Path) -> u64 {
     let my_addr = Uint256::from_u64(1025);
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), false, false);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, false);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract
@@ -119,7 +119,7 @@ pub fn benchmark_add_batched(iterations: u64, log_to: &Path) -> u64 {
     let my_addr = Uint256::from_u64(1025);
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), false, false);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, false);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -46,7 +46,7 @@ pub fn evm_xcontract_call_with_constructors(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), false, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), None, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -58,7 +58,7 @@ pub fn evm_xcontract_call_with_constructors(
         ))],
         &mut machine,
         Uint256::zero(),
-        false,
+        None,
         debug,
     ) == None
     {
@@ -277,7 +277,7 @@ pub fn evm_test_create(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), false, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), None, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -289,7 +289,7 @@ pub fn evm_test_create(
         ))],
         &mut machine,
         Uint256::zero(),
-        false,
+        None,
         debug,
     ) == None
     {
@@ -342,7 +342,7 @@ pub fn evm_xcontract_call_using_batch(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), false, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), None, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -354,7 +354,7 @@ pub fn evm_xcontract_call_using_batch(
         ))],
         &mut machine,
         Uint256::zero(),
-        false,
+        None,
         debug,
     ) == None
     {
@@ -452,7 +452,7 @@ pub fn _evm_xcontract_call_using_compressed_batch(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), false, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, Uint256::zero(), None, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -464,7 +464,7 @@ pub fn _evm_xcontract_call_using_compressed_batch(
         ))],
         &mut machine,
         Uint256::zero(),
-        false,
+        None,
         debug,
     ) == None
     {
@@ -539,7 +539,7 @@ pub fn evm_direct_deploy_add(log_to: Option<&Path>, debug: bool) {
 
     match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), false, debug);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
             } else {
@@ -563,7 +563,7 @@ pub fn evm_deploy_buddy_contract(log_to: Option<&Path>, debug: bool) {
 
     match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), true, debug);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), Some(Uint256::from_u64(1025)), debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
             } else {
@@ -604,7 +604,7 @@ pub fn evm_test_payment_in_constructor(log_to: Option<&Path>, debug: bool) {
                 &vec![],
                 &mut machine,
                 Uint256::from_u64(10000),
-                false,
+                None,
                 debug,
             );
             if let Some(contract_addr) = result {
@@ -673,7 +673,7 @@ pub fn evm_test_arbsys(log_to: Option<&Path>, debug: bool) {
 
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&vec![], &mut machine, Uint256::zero(), false, debug);
+            let result = contract.deploy(&vec![], &mut machine, Uint256::zero(), None, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract
@@ -756,7 +756,7 @@ pub fn evm_direct_deploy_and_call_add(log_to: Option<&Path>, debug: bool) {
     let my_addr = Uint256::from_usize(1025);
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), false, debug);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract
@@ -806,6 +806,75 @@ pub fn evm_direct_deploy_and_call_add(log_to: Option<&Path>, debug: bool) {
     }
 }
 
+pub fn _evm_test_same_address_deploy(log_to: Option<&Path>, debug: bool) {
+    use std::convert::TryFrom;
+    let rt_env = RuntimeEnvironment::new(Uint256::from_usize(1111));
+    let mut machine = load_from_file(Path::new("arb_os/arbos.mexe"), rt_env);
+    machine.start_at_zero();
+
+    let my_addr = Uint256::from_usize(1025);
+    let (contract, orig_contract_addr) = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
+        Ok(mut contract) => {
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
+            if let Some(contract_addr) = result {
+                assert_ne!(contract_addr, Uint256::zero());
+                (contract, contract_addr)
+            } else {
+                panic!("deploy failed");
+            }
+        }
+        Err(e) => {
+            panic!("error loading contract: {:?}", e);
+        }
+    };
+
+    match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
+        Ok(mut new_contract) => {
+            let result = new_contract.deploy(&[], &mut machine, Uint256::zero(), Some(orig_contract_addr), debug);
+            assert_eq!(result, None);
+        }
+        Err(e) => {
+            panic!("error loading contract: {:?}", e);
+        }
+    };
+
+    let result = contract.call_function(
+        my_addr,
+        "add",
+        vec![
+            ethabi::Token::Uint(ethabi::Uint::one()),
+            ethabi::Token::Uint(ethabi::Uint::one()),
+        ]
+            .as_ref(),
+        &mut machine,
+        Uint256::zero(),
+        debug,
+    );
+    match result {
+        Ok((logs, sends)) => {
+            assert_eq!(logs.len(), 1);
+            assert_eq!(sends.len(), 0);
+            assert!(logs[0].succeeded());
+            let decoded_result = contract
+                .get_function("add")
+                .unwrap()
+                .decode_output(&logs[0].get_return_data())
+                .unwrap();
+            assert_eq!(
+                decoded_result[0],
+                ethabi::Token::Uint(ethabi::Uint::try_from(2).unwrap())
+            );
+        }
+        Err(e) => {
+            panic!(e.to_string());
+        }
+    }
+
+    if let Some(path) = log_to {
+        machine.runtime_env.recorder.to_file(path).unwrap();
+    }
+}
+
 pub fn evm_direct_deploy_and_compressed_call_add(log_to: Option<&Path>, debug: bool) {
     use std::convert::TryFrom;
     let rt_env = RuntimeEnvironment::new(Uint256::from_usize(1111));
@@ -816,7 +885,7 @@ pub fn evm_direct_deploy_and_compressed_call_add(log_to: Option<&Path>, debug: b
     let my_addr = Uint256::from_bytes(wallet.address().as_bytes());
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), false, debug);
+            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract

--- a/src/minitests.rs
+++ b/src/minitests.rs
@@ -396,6 +396,11 @@ fn test_function_table_access() {
 }
 
 #[test]
+fn test_same_address_deploy() {
+    crate::evm::_evm_test_same_address_deploy(None, false);
+}
+
+#[test]
 pub fn test_crosscontract_call_with_constructors() {
     match crate::evm::evm_xcontract_call_with_constructors(None, false, false) {
         Ok(result) => assert_eq!(result, true),


### PR DESCRIPTION
This ensures that if there are multiple attempts to deploy contracts at the same address, only the first one will succeed. Subsequent deploy attempts at the same address will fail, with the tx receipt containing a new failure code.

This scenario can only come up in a rare case where:
(1) an EOA deploys a contract on Ethereum using nonce N
(2) the same EOA deploys a contract on an Arbitrum chain using the same nonce N, and
(3) the Ethereum contract deployed in step 1 deploys a buddy contract on the Arbitrum chain
(Note that the same steps can also happen in other orders.)

We enforce the principle that once a contract is deployed at an address, nothing can dislodge or replace it. The only way the contract can be eliminated is if it self-destructs.

Fixes #238 

This should not require any changes to other modules.