### PR TITLE
Fix incorrect handling of INVALID EVM instruction

### DIFF
--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -520,6 +520,9 @@ public impure func translateEvmCodeSegment(
                             evmJumpTable,
                             pcTable,
                         )?;
+                        if (opcode == 0xfe) {  // INVALID
+                            doCall = pushValue(0, pushValue(0, doCall));  // treat as equivalent to revert(0,0)
+                        }
                         return Some((
                             pushValue(
                                 numBytesRead-1,


### PR DESCRIPTION
This fixes a regression in #251 .  The change in that PR caused the EVM transpiler to generate incorrect code for the EVM INVALID instruction. 