### PR TITLE
Rescale ArbGas by a factor of 1000

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -355,7 +355,7 @@ public impure func evmCallStack_doCall(
             // Add a stipend, charged to the caller, if non-zero value is transferred.
             // This is needed because Ethereum provides a stipend, and some code depends on that.
             // The size of our stipend was chosen experimentally, to make sure a call that will run on Ethereum will run here.
-            gas = gas + 20000;
+            gas = gas + 20;
         }
         if (gas > availableGas) {
             gas = availableGas;  // don't give the callee more gas than the caller has
@@ -414,10 +414,9 @@ public impure func evmCallStack_doCall(
             callvalue: balance,
             returnInfo: None<ReturnInfo>,
             memory: bytearray_new(0),
-            revertOnStorageWrite: // disallow storage write if gas provided < EVM gas cost of storage write
+            revertOnStorageWrite: // disallow storage write if this is a transfer funded entirely by the subsidy
                                   topFrame.revertOnStorageWrite
-                                  || (gas < 5000)
-                                  || ((balance > 0) && (gas < 7700)),
+                                  || ((balance > 0) && (gas <= 20)),
             evmLogs: topFrame.evmLogs,
             selfDestructQueue: topFrame.selfDestructQueue,
             resumeInfo: None<ResumeInfo>,

--- a/arb_os/evmOps.mini
+++ b/arb_os/evmOps.mini
@@ -881,7 +881,7 @@ impure func doCreationOpcode(value: uint, offset: uint, length: uint, newAddress
             //     we can't (yet) trust that our local callframe is in a reasonable state.
             //     So we have to use an if-statement to capture the return value.
             if (evmOp_call(
-                1000000000,  // gas allocation
+                1000000,  // gas allocation
                 uint(newAddress),
                 value,
                 0,           // no calldata passed to constructor

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -80,8 +80,8 @@ public impure func gasAccounting_startTxCharges(
     // Start charging a new Tx for ArbGas usage
     // The caller should already have verified that the payer has enough funds, but we'll return None if not.
 
-    if (maxGas >= asm(255, 1) uint { shl }) {
-        maxGas = asm(255, 1) uint { shl } - 1;
+    if (maxGas >= asm(255, 1) uint { shl } / 1000) {
+        maxGas = (asm(255, 1) uint { shl } / 1000) - 1;
     }
 
     // take funds from the payer, enough to pay for maxGas at gasPrice
@@ -110,7 +110,7 @@ public impure func gasAccounting_startTxCharges(
         })
     };
 
-    asm(maxGas,) { setgas };
+    asm(1000*maxGas,) { setgas };
     return Some(());
 }
 
@@ -157,18 +157,19 @@ public impure func gasAccounting_extraGasCharge(numArbGas: uint) {
     // callers should assess the charge for a thing before they do the thing, because we can
     //      only take the gas that the user has remaining
 
-    let gasLeft = asm() uint { getgas };
-    if (gasLeft >= asm (1, 255) uint { shl }) {
+    let gasLeftMillis = asm() uint { getgas };
+    if (gasLeftMillis >= asm (1, 255) uint { shl }) {
         return;   // we're not currently charging a tx, so don't assess a charge
     }
+    let numArbGasMillis = numArbGas * 1000;
 
-    if (numArbGas >= gasLeft) {
+    if (numArbGasMillis >= gasLeftMillis) {
         // user can't cover the charge, so we'll take all but 1 of their gas,
         //      ensuring that they'll get an out-of-gas error
-        numArbGas = gasLeft-1;
+        numArbGasMillis = gasLeftMillis-1;
     }
 
-    asm(gasLeft-numArbGas,) { setgas };
+    asm(gasLeftMillis-numArbGasMillis,) { setgas };
 }
 
 public impure func gasAccounting_pauseTxCharges() -> uint {
@@ -209,7 +210,7 @@ public impure func gasAccounting_resumeTxCharges(allocationRequested: uint) -> u
             )
         };
 
-        asm(allocationRequested,) { setgas };  // start charging the application
+        asm(allocationRequested*1000,) { setgas };  // start charging the application
         return allocationRequested;
     } else {
         // something went wrong: tried to resume tx charges when there isn't an active tx
@@ -221,14 +222,14 @@ public impure func gasAccounting_resumeTxCharges(allocationRequested: uint) -> u
 impure func switchToChargingOS() -> uint {
     // switch to charging the OS for gas, if we aren't already
     // return amount of the tx's gas that was left over in ArbGasRemaining
-    let gasRemaining = asm() uint { getgas };
-    if (gasRemaining >= asm(255, 1) uint { shl }) {
+    let gasRemainingMillis = asm() uint { getgas };
+    if (gasRemainingMillis >= asm(255, 1) uint { shl }) {
         // we were already charging the OS, tx has nothing remaining
         return 0;
     } else {
         // we were charging the tx; switch to charging the OS and return tx's unused amount from ArbGasRemaining
         asm(~0,) { setgas };
-        return gasRemaining;
+        return gasRemainingMillis/1000;
     }
 }
 

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -241,7 +241,7 @@ public impure func inbox_getNextUnpackedRequest() -> (
         } else {
             // it's not a batch, so process it immediately
             // get its maxGas amount -- for now, set the limit high, unless caller asked for less
-            let maxGas = 1000000000;
+            let maxGas = 1000000;
             if (msg.kind == 6) {
                 // it's an end-of-block message, so just trigger end-of-block processing
                 outputStats_endOfBlock(msg.blockNumber, msg.timestamp);

--- a/arb_os/tokens.mini
+++ b/arb_os/tokens.mini
@@ -73,7 +73,7 @@ public impure func tokens_erc20deposit(
     initEvmCallStack(
         0,               // treat as regular txcall
         struct {
-            maxGas: 1000000000000,  // gas will eventually be charged to the OS
+            maxGas: 1000000000,  // gas will eventually be charged to the OS
             gasPrice: 0,
             seqNum: None<uint>,
             caller: address(1),     // special caller address, so contract recognizes call as coming from OS
@@ -128,7 +128,7 @@ public impure func tokens_erc721deposit(
     initEvmCallStack(
         0,               // treat as regular txcall
         struct {
-            maxGas: 1000000000000,  // gas will eventually be charged to the OS
+            maxGas: 1000000000,  // gas will eventually be charged to the OS
             gasPrice: 0,
             seqNum: None<uint>,
             caller: address(1),     // special caller address, so contract recognizes call as coming from OS


### PR DESCRIPTION
Rescale ArbGas by a factor of 1000, so what used to be 100,000 ArbGas is now 100 ArbGas.  

Basically this treats the AVM's ArbGasRemaining register as if it measures milli-ArbGas, with 1000 units of the register corresponding to 1 ArbGas.  ArbOS's data structures keep track of the rescaled gas--only the AVM register uses the original scaling.

One consequence of this is that transactions will use much less ArbGas, compared to the amount of L1 gas they would require. So dapps that give low amounts of gas to limit what callees can do probably won't enforce those limits effectively. (An exception is that a zero-gas transaction that makes an ETH transfer will be prevented from modifying storage, even though it will receive an automatic gas stipend.)

This will require changes to the AVM specification, to reduce the gas usage of all operations by a factor of 1000 (and to say that the gas usage of an activity is rounded up to an integer).