### PR TITLE
Refactor ast

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -732,8 +732,8 @@ pub enum MatchPattern {
 /// contains a condition, and Catchall(block, location) if it is an else block.
 #[derive(Debug, Clone)]
 pub enum IfArm {
-    Cond(Expr, Vec<Statement>, Option<Box<IfArm>>, Option<Location>),
-    Catchall(Vec<Statement>, Option<Location>),
+    Cond(Expr, Vec<Statement>, Option<Box<IfArm>>, DebugInfo),
+    Catchall(Vec<Statement>, DebugInfo),
 }
 
 impl IfArm {

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -19,9 +19,15 @@ use std::collections::HashMap;
 pub type TypeTree = HashMap<(Vec<String>, usize), Type>;
 
 ///Debugging info serialized into mini executables, currently only contains a location.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct DebugInfo {
     pub location: Option<Location>,
+}
+
+impl From<Option<Location>> for DebugInfo {
+    fn from(location: Option<Location>) -> Self {
+        DebugInfo { location }
+    }
 }
 
 ///A top level language declaration.  Represents any language construct that can be directly
@@ -873,7 +879,7 @@ impl Expr {
     pub fn new_unary(op: UnaryOp, e: Expr, loc: Option<Location>) -> Self {
         Self {
             kind: ExprKind::UnaryOp(op, Box::new(e)),
-            debug_info: DebugInfo { location: loc },
+            debug_info: DebugInfo::from(loc),
         }
     }
 
@@ -881,7 +887,7 @@ impl Expr {
     pub fn new_binary(op: BinaryOp, e1: Expr, e2: Expr, loc: Option<Location>) -> Self {
         Self {
             kind: ExprKind::Binary(op, Box::new(e1), Box::new(e2)),
-            debug_info: DebugInfo { location: loc },
+            debug_info: DebugInfo::from(loc),
         }
     }
 

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 pub type TypeTree = HashMap<(Vec<String>, usize), Type>;
 
 ///Debugging info serialized into mini executables, currently only contains a location.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct DebugInfo {
     pub location: Option<Location>,
 }
@@ -835,107 +835,125 @@ impl Constant {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub debug_info: DebugInfo,
+}
+
 ///A mini expression that has not yet been type checked.
 #[derive(Debug, Clone)]
-pub enum Expr {
-    UnaryOp(UnaryOp, Box<Expr>, Option<Location>),
-    Binary(BinaryOp, Box<Expr>, Box<Expr>, Option<Location>),
-    ShortcutOr(Box<Expr>, Box<Expr>, Option<Location>),
-    ShortcutAnd(Box<Expr>, Box<Expr>, Option<Location>),
-    VariableRef(StringId, Option<Location>),
-    TupleRef(Box<Expr>, Uint256, Option<Location>),
-    DotRef(Box<Expr>, String, Option<Location>),
-    Constant(Constant, Option<Location>),
-    OptionInitializer(Box<Expr>, Option<Location>),
-    FunctionCall(Box<Expr>, Vec<Expr>, Option<Location>),
-    CodeBlock(Vec<Statement>, Option<Box<Expr>>, Option<Location>),
-    ArrayOrMapRef(Box<Expr>, Box<Expr>, Option<Location>),
-    StructInitializer(Vec<FieldInitializer>, Option<Location>),
-    Tuple(Vec<Expr>, Option<Location>),
-    NewArray(Box<Expr>, Type, Option<Location>),
-    NewFixedArray(usize, Option<Box<Expr>>, Option<Location>),
-    NewMap(Type, Type, Option<Location>),
-    ArrayOrMapMod(Box<Expr>, Box<Expr>, Box<Expr>, Option<Location>),
-    StructMod(Box<Expr>, String, Box<Expr>, Option<Location>),
-    UnsafeCast(Box<Expr>, Type, Option<Location>),
-    Asm(Type, Vec<Instruction>, Vec<Expr>, Option<Location>),
-    Try(Box<Expr>, Option<Location>),
+pub enum ExprKind {
+    UnaryOp(UnaryOp, Box<Expr>),
+    Binary(BinaryOp, Box<Expr>, Box<Expr>),
+    ShortcutOr(Box<Expr>, Box<Expr>),
+    ShortcutAnd(Box<Expr>, Box<Expr>),
+    VariableRef(StringId),
+    TupleRef(Box<Expr>, Uint256),
+    DotRef(Box<Expr>, String),
+    Constant(Constant),
+    OptionInitializer(Box<Expr>),
+    FunctionCall(Box<Expr>, Vec<Expr>),
+    CodeBlock(Vec<Statement>, Option<Box<Expr>>),
+    ArrayOrMapRef(Box<Expr>, Box<Expr>),
+    StructInitializer(Vec<FieldInitializer>),
+    Tuple(Vec<Expr>),
+    NewArray(Box<Expr>, Type),
+    NewFixedArray(usize, Option<Box<Expr>>),
+    NewMap(Type, Type),
+    ArrayOrMapMod(Box<Expr>, Box<Expr>, Box<Expr>),
+    StructMod(Box<Expr>, String, Box<Expr>),
+    UnsafeCast(Box<Expr>, Type),
+    Asm(Type, Vec<Instruction>, Vec<Expr>),
+    Try(Box<Expr>),
 }
 
 impl Expr {
     ///Returns an expression that applies unary operator op to e.
     pub fn new_unary(op: UnaryOp, e: Expr, loc: Option<Location>) -> Self {
-        Expr::UnaryOp(op, Box::new(e), loc)
+        Self {
+            kind: ExprKind::UnaryOp(op, Box::new(e)),
+            debug_info: DebugInfo { location: loc },
+        }
     }
 
     ///Returns an expression that applies binary operator op to e1 and e2.
     pub fn new_binary(op: BinaryOp, e1: Expr, e2: Expr, loc: Option<Location>) -> Self {
-        Expr::Binary(op, Box::new(e1), Box::new(e2), loc)
+        Self {
+            kind: ExprKind::Binary(op, Box::new(e1), Box::new(e2)),
+            debug_info: DebugInfo { location: loc },
+        }
     }
 
+    pub fn resolve_types(&self, type_table: &SymTable<Type>) -> Result<Self, TypeError> {
+        Ok(Self {
+            kind: self
+                .kind
+                .resolve_types(type_table, self.debug_info.location)?,
+            debug_info: self.debug_info.clone(),
+        })
+    }
+}
+
+impl ExprKind {
     ///Returns either a fully specified version of self specified by matching Named types to the
     /// contents of type_table, or a TypeError if a Named type does not have an associated entry.
-    pub fn resolve_types(&self, type_table: &SymTable<Type>) -> Result<Self, TypeError> {
+    pub fn resolve_types(
+        &self,
+        type_table: &SymTable<Type>,
+        loc: Option<Location>,
+    ) -> Result<Self, TypeError> {
         match self {
-            Expr::UnaryOp(op, be, loc) => Ok(Expr::UnaryOp(
+            ExprKind::UnaryOp(op, be) => Ok(ExprKind::UnaryOp(
                 *op,
                 Box::new(be.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::Binary(op, be1, be2, loc) => Ok(Expr::Binary(
+            ExprKind::Binary(op, be1, be2) => Ok(ExprKind::Binary(
                 *op,
                 Box::new(be1.resolve_types(type_table)?),
                 Box::new(be2.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::ShortcutOr(be1, be2, loc) => Ok(Expr::ShortcutOr(
+            ExprKind::ShortcutOr(be1, be2) => Ok(ExprKind::ShortcutOr(
                 Box::new(be1.resolve_types(type_table)?),
                 Box::new(be2.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::ShortcutAnd(be1, be2, loc) => Ok(Expr::ShortcutAnd(
+            ExprKind::ShortcutAnd(be1, be2) => Ok(ExprKind::ShortcutAnd(
                 Box::new(be1.resolve_types(type_table)?),
                 Box::new(be2.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::VariableRef(name, loc) => Ok(Expr::VariableRef(*name, *loc)),
-            Expr::TupleRef(be, idx, loc) => Ok(Expr::TupleRef(
+            ExprKind::VariableRef(name) => Ok(ExprKind::VariableRef(*name)),
+            ExprKind::TupleRef(be, idx) => Ok(ExprKind::TupleRef(
                 Box::new(be.resolve_types(type_table)?),
                 idx.clone(),
-                *loc,
             )),
-            Expr::DotRef(be, name, loc) => Ok(Expr::DotRef(
+            ExprKind::DotRef(be, name) => Ok(ExprKind::DotRef(
                 Box::new(be.resolve_types(type_table)?),
                 name.clone(),
-                *loc,
             )),
-            Expr::Constant(b, loc) => Ok(Expr::Constant(b.resolve_types(type_table)?, *loc)),
-            Expr::FunctionCall(fexpr, args, loc) => {
+            ExprKind::Constant(b) => Ok(ExprKind::Constant(b.resolve_types(type_table)?)),
+            ExprKind::FunctionCall(fexpr, args) => {
                 let mut rargs = Vec::new();
                 for arg in args.iter() {
                     rargs.push(arg.resolve_types(type_table)?);
                 }
-                Ok(Expr::FunctionCall(
+                Ok(ExprKind::FunctionCall(
                     Box::new(fexpr.resolve_types(type_table)?),
                     rargs,
-                    *loc,
                 ))
             }
-            Expr::CodeBlock(body, result, loc) => Ok(Expr::CodeBlock(
+            ExprKind::CodeBlock(body, result) => Ok(ExprKind::CodeBlock(
                 Statement::resolve_types_vec(body.to_vec(), type_table)?,
                 result
                     .clone()
                     .map(|exp| exp.resolve_types(type_table))
                     .transpose()?
                     .map(Box::new),
-                *loc,
             )),
-            Expr::ArrayOrMapRef(e1, e2, loc) => Ok(Expr::ArrayOrMapRef(
+            ExprKind::ArrayOrMapRef(e1, e2) => Ok(ExprKind::ArrayOrMapRef(
                 Box::new(e1.resolve_types(type_table)?),
                 Box::new(e2.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::StructInitializer(fields, loc) => {
+            ExprKind::StructInitializer(fields) => {
                 let mut rfields = Vec::new();
                 for field in fields.iter() {
                     rfields.push(FieldInitializer::new(
@@ -943,67 +961,59 @@ impl Expr {
                         field.value.resolve_types(type_table)?,
                     ));
                 }
-                Ok(Expr::StructInitializer(rfields, *loc))
+                Ok(ExprKind::StructInitializer(rfields))
             }
-            Expr::OptionInitializer(inner, loc) => Ok(Expr::OptionInitializer(
-                Box::new(inner.resolve_types(type_table)?),
-                *loc,
-            )),
-            Expr::Tuple(evec, loc) => {
+            ExprKind::OptionInitializer(inner) => Ok(ExprKind::OptionInitializer(Box::new(
+                inner.resolve_types(type_table)?,
+            ))),
+            ExprKind::Tuple(evec) => {
                 let mut rvec = Vec::new();
                 for expr in evec {
                     rvec.push(expr.resolve_types(type_table)?);
                 }
-                Ok(Expr::Tuple(rvec, *loc))
+                Ok(ExprKind::Tuple(rvec))
             }
-            Expr::NewArray(sz, tipe, loc) => Ok(Expr::NewArray(
+            ExprKind::NewArray(sz, tipe) => Ok(ExprKind::NewArray(
                 Box::new(sz.resolve_types(type_table)?),
-                tipe.resolve_types(type_table, *loc)?,
-                *loc,
+                tipe.resolve_types(type_table, loc)?,
             )),
-            Expr::NewFixedArray(sz, init_expr, loc) => match &*init_expr {
-                Some(expr) => Ok(Expr::NewFixedArray(
+            ExprKind::NewFixedArray(sz, init_expr) => match &*init_expr {
+                Some(expr) => Ok(ExprKind::NewFixedArray(
                     *sz,
                     Some(Box::new(expr.resolve_types(type_table)?)),
-                    *loc,
                 )),
-                None => Ok(Expr::NewFixedArray(*sz, None, *loc)),
+                None => Ok(ExprKind::NewFixedArray(*sz, None)),
             },
-            Expr::NewMap(key_type, value_type, loc) => Ok(Expr::NewMap(
-                key_type.resolve_types(type_table, *loc)?,
-                value_type.resolve_types(type_table, *loc)?,
-                *loc,
+            ExprKind::NewMap(key_type, value_type) => Ok(ExprKind::NewMap(
+                key_type.resolve_types(type_table, loc)?,
+                value_type.resolve_types(type_table, loc)?,
             )),
-            Expr::ArrayOrMapMod(e1, e2, e3, loc) => Ok(Expr::ArrayOrMapMod(
+            ExprKind::ArrayOrMapMod(e1, e2, e3) => Ok(ExprKind::ArrayOrMapMod(
                 Box::new(e1.resolve_types(type_table)?),
                 Box::new(e2.resolve_types(type_table)?),
                 Box::new(e3.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::StructMod(e1, i, e3, loc) => Ok(Expr::StructMod(
+            ExprKind::StructMod(e1, i, e3) => Ok(ExprKind::StructMod(
                 Box::new(e1.resolve_types(type_table)?),
                 i.clone(),
                 Box::new(e3.resolve_types(type_table)?),
-                *loc,
             )),
-            Expr::UnsafeCast(be, t, loc) => Ok(Expr::UnsafeCast(
+            ExprKind::UnsafeCast(be, t) => Ok(ExprKind::UnsafeCast(
                 Box::new(be.resolve_types(type_table)?),
-                t.resolve_types(type_table, *loc)?,
-                *loc,
+                t.resolve_types(type_table, loc)?,
             )),
-            Expr::Asm(t, insns, exprs, loc) => {
+            ExprKind::Asm(t, insns, exprs) => {
                 let mut res_exprs = Vec::new();
                 for ex in exprs {
                     res_exprs.push(ex.resolve_types(type_table)?);
                 }
-                Ok(Expr::Asm(
-                    t.resolve_types(type_table, *loc)?,
+                Ok(ExprKind::Asm(
+                    t.resolve_types(type_table, loc)?,
                     insns.to_vec(),
                     res_exprs,
-                    *loc,
                 ))
             }
-            Expr::Try(expr, loc) => Ok(Expr::Try(Box::new(expr.resolve_types(type_table)?), *loc)),
+            ExprKind::Try(expr) => Ok(ExprKind::Try(Box::new(expr.resolve_types(type_table)?))),
         }
     }
 }

--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -1492,13 +1492,13 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_arrayGet").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![*expr1.clone(), *expr2.clone()],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,
@@ -1590,13 +1590,13 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_kvsGet").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![*map_expr.clone(), *key_expr.clone()],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,
@@ -1626,19 +1626,19 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_arrayNew").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![
                         *sz_expr.clone(),
                         TypeCheckedExpr {
                             kind: TypeCheckedExprKind::Const(default_val, Type::Any),
-                            debug_info: DebugInfo { location: loc },
+                            debug_info: DebugInfo::from(loc),
                         },
                     ],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,
@@ -1737,13 +1737,13 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_kvsNew").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,
@@ -1772,13 +1772,13 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_arraySet").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![*arr.clone(), *index.clone(), *val.clone()],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,
@@ -1828,13 +1828,13 @@ fn mavm_codegen_expr<'a>(
                             *string_table.get_if_exists("builtin_kvsSet").unwrap(),
                             call_type.clone(),
                         ),
-                        debug_info: DebugInfo { location: loc },
+                        debug_info: DebugInfo::from(loc),
                     }),
                     vec![*map_expr.clone(), *key_expr.clone(), *val_expr.clone()],
                     call_type,
                     PropertiesList { pure: true },
                 ),
-                debug_info: DebugInfo { location: loc },
+                debug_info: DebugInfo::from(loc),
             };
             mavm_codegen_expr(
                 &the_expr,

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -451,9 +451,14 @@ pub fn compile_from_folder(
         name,
     } in typechecked
     {
-        let code_out =
-            codegen::mavm_codegen(checked_funcs, &string_table, &imported_funcs, &global_vars, file_name_chart)
-                .map_err(|e| CompileError::new(e.reason.to_string(), e.location))?;
+        let code_out = codegen::mavm_codegen(
+            checked_funcs,
+            &string_table,
+            &imported_funcs,
+            &global_vars,
+            file_name_chart,
+        )
+        .map_err(|e| CompileError::new(e.reason.to_string(), e.location))?;
         progs.push(CompiledProgram::new(
             code_out.to_vec(),
             exported_funcs,

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -146,7 +146,7 @@ fn inline(
                                 ),
                                 arg.clone(),
                             ),
-                            debug_info: DebugInfo { location: None },
+                            debug_info: DebugInfo::from(None),
                         })
                         .collect();
                     code.append(&mut func.code.clone());
@@ -1326,7 +1326,7 @@ fn typecheck_statement<'a>(
     Ok((
         TypeCheckedStatement {
             kind: stat,
-            debug_info: DebugInfo { location: *loc },
+            debug_info: DebugInfo::from(*loc),
         },
         binds,
     ))
@@ -1661,7 +1661,7 @@ fn typecheck_expr(
                                     v.len(),
                                     sf.tipe.clone(),
                                 ),
-                                debug_info: DebugInfo { location: loc },
+                                debug_info: DebugInfo::from(loc),
                             });
                         }
                     }
@@ -2152,7 +2152,7 @@ fn typecheck_expr(
                 }
             }
         }?,
-        debug_info: DebugInfo { location: loc },
+        debug_info: DebugInfo::from(loc),
     })
 }
 

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -328,9 +328,9 @@ pub enum TypeCheckedIfArm {
         TypeCheckedExpr,
         Vec<TypeCheckedStatement>,
         Option<Box<TypeCheckedIfArm>>,
-        Option<Location>,
+        DebugInfo,
     ),
-    Catchall(Vec<TypeCheckedStatement>, Option<Location>),
+    Catchall(Vec<TypeCheckedStatement>, DebugInfo),
 }
 
 impl AbstractSyntaxTree for TypeCheckedIfArm {
@@ -1395,7 +1395,8 @@ fn typecheck_if_arm(
     scopes: &mut Vec<(String, Option<Type>)>,
 ) -> Result<TypeCheckedIfArm, TypeError> {
     match arm {
-        IfArm::Cond(cond, body, orest, loc) => {
+        IfArm::Cond(cond, body, orest, debug_info) => {
+            let loc = debug_info.location;
             let tc_cond = typecheck_expr(
                 cond,
                 type_table,
@@ -1429,11 +1430,11 @@ fn typecheck_if_arm(
                         )?)),
                         None => None,
                     },
-                    *loc,
+                    debug_info.clone(),
                 )),
                 _ => Err(new_type_error(
                     "if condition must be boolean".to_string(),
-                    *loc,
+                    loc,
                 )),
             }
         }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -123,8 +123,16 @@ fn inline(
     _mut_state: &mut (),
 ) -> bool {
     if let TypeCheckedNode::Expression(exp) = to_do {
-        if let TypeCheckedExpr::FunctionCall(name, args, _, _, _) = exp {
-            let (mut code, block_exp) = if let TypeCheckedExpr::FuncRef(id, _, _) = **name {
+        if let TypeCheckedExpr {
+            kind: TypeCheckedExprKind::FunctionCall(name, args, _, _),
+            debug_info: _,
+        } = exp
+        {
+            let (mut code, block_exp) = if let TypeCheckedExpr {
+                kind: TypeCheckedExprKind::FuncRef(id, _),
+                debug_info: _,
+            } = **name
+            {
                 let found_func = state.0.iter().find(|func| func.name == id);
                 if let Some(func) = found_func {
                     let mut code: Vec<_> = args
@@ -167,7 +175,7 @@ fn inline(
             for statement in code.iter_mut().rev() {
                 statement.recursive_apply(strip_returns, &(), &mut ())
             }
-            **exp = TypeCheckedExpr::CodeBlock(code, block_exp, Some("_inline".to_string()), None);
+            exp.kind = TypeCheckedExprKind::CodeBlock(code, block_exp, Some("_inline".to_string()));
             false
         } else {
             true
@@ -366,75 +374,50 @@ impl MiniProperties for TypeCheckedIfArm {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TypeCheckedExpr {
+    pub kind: TypeCheckedExprKind,
+    pub debug_info: DebugInfo,
+}
+
 ///A mini expression that has been type checked.
 #[derive(Debug, Clone)]
-pub enum TypeCheckedExpr {
-    UnaryOp(UnaryOp, Box<TypeCheckedExpr>, Type, Option<Location>),
-    Binary(
-        BinaryOp,
-        Box<TypeCheckedExpr>,
-        Box<TypeCheckedExpr>,
-        Type,
-        Option<Location>,
-    ),
-    ShortcutOr(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, Option<Location>),
-    ShortcutAnd(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, Option<Location>),
-    LocalVariableRef(StringId, Type, Option<Location>),
-    GlobalVariableRef(usize, Type, Option<Location>),
-    Variant(Box<TypeCheckedExpr>, Option<Location>),
-    FuncRef(usize, Type, Option<Location>),
-    TupleRef(Box<TypeCheckedExpr>, Uint256, Type, Option<Location>),
-    DotRef(
-        Box<TypeCheckedExpr>,
-        StringId,
-        usize,
-        Type,
-        Option<Location>,
-    ),
-    Const(Value, Type, Option<Location>),
+pub enum TypeCheckedExprKind {
+    UnaryOp(UnaryOp, Box<TypeCheckedExpr>, Type),
+    Binary(BinaryOp, Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, Type),
+    ShortcutOr(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>),
+    ShortcutAnd(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>),
+    LocalVariableRef(StringId, Type),
+    GlobalVariableRef(usize, Type),
+    Variant(Box<TypeCheckedExpr>),
+    FuncRef(usize, Type),
+    TupleRef(Box<TypeCheckedExpr>, Uint256, Type),
+    DotRef(Box<TypeCheckedExpr>, StringId, usize, Type),
+    Const(Value, Type),
     FunctionCall(
         Box<TypeCheckedExpr>,
         Vec<TypeCheckedExpr>,
         Type,
         PropertiesList,
-        Option<Location>,
     ),
     CodeBlock(
         Vec<TypeCheckedStatement>,
         Option<Box<TypeCheckedExpr>>,
         Option<String>,
-        Option<Location>,
     ),
-    StructInitializer(Vec<TypeCheckedStructField>, Type, Option<Location>),
-    ArrayRef(
-        Box<TypeCheckedExpr>,
-        Box<TypeCheckedExpr>,
-        Type,
-        Option<Location>,
-    ),
-    FixedArrayRef(
-        Box<TypeCheckedExpr>,
-        Box<TypeCheckedExpr>,
-        usize,
-        Type,
-        Option<Location>,
-    ),
-    MapRef(
-        Box<TypeCheckedExpr>,
-        Box<TypeCheckedExpr>,
-        Type,
-        Option<Location>,
-    ),
-    Tuple(Vec<TypeCheckedExpr>, Type, Option<Location>),
-    NewArray(Box<TypeCheckedExpr>, Type, Type, Option<Location>),
-    NewFixedArray(usize, Option<Box<TypeCheckedExpr>>, Type, Option<Location>),
-    NewMap(Type, Option<Location>),
+    StructInitializer(Vec<TypeCheckedStructField>, Type),
+    ArrayRef(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, Type),
+    FixedArrayRef(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, usize, Type),
+    MapRef(Box<TypeCheckedExpr>, Box<TypeCheckedExpr>, Type),
+    Tuple(Vec<TypeCheckedExpr>, Type),
+    NewArray(Box<TypeCheckedExpr>, Type, Type),
+    NewFixedArray(usize, Option<Box<TypeCheckedExpr>>, Type),
+    NewMap(Type),
     ArrayMod(
         Box<TypeCheckedExpr>,
         Box<TypeCheckedExpr>,
         Box<TypeCheckedExpr>,
         Type,
-        Option<Location>,
     ),
     FixedArrayMod(
         Box<TypeCheckedExpr>,
@@ -442,129 +425,116 @@ pub enum TypeCheckedExpr {
         Box<TypeCheckedExpr>,
         usize,
         Type,
-        Option<Location>,
     ),
     MapMod(
         Box<TypeCheckedExpr>,
         Box<TypeCheckedExpr>,
         Box<TypeCheckedExpr>,
         Type,
-        Option<Location>,
     ),
-    StructMod(
-        Box<TypeCheckedExpr>,
-        usize,
-        Box<TypeCheckedExpr>,
-        Type,
-        Option<Location>,
-    ),
-    Cast(Box<TypeCheckedExpr>, Type, Option<Location>),
-    Asm(
-        Type,
-        Vec<Instruction>,
-        Vec<TypeCheckedExpr>,
-        Option<Location>,
-    ),
-    Try(Box<TypeCheckedExpr>, Type, Option<Location>),
+    StructMod(Box<TypeCheckedExpr>, usize, Box<TypeCheckedExpr>, Type),
+    Cast(Box<TypeCheckedExpr>, Type),
+    Asm(Type, Vec<Instruction>, Vec<TypeCheckedExpr>),
+    Try(Box<TypeCheckedExpr>, Type),
 }
 
 impl MiniProperties for TypeCheckedExpr {
     fn is_pure(&self) -> bool {
-        match self {
-            TypeCheckedExpr::UnaryOp(_, expr, _, _) => expr.is_pure(),
-            TypeCheckedExpr::Binary(_, left, right, _, _) => left.is_pure() && right.is_pure(),
-            TypeCheckedExpr::ShortcutOr(left, right, _) => left.is_pure() && right.is_pure(),
-            TypeCheckedExpr::ShortcutAnd(left, right, _) => left.is_pure() && right.is_pure(),
-            TypeCheckedExpr::LocalVariableRef(_, _, _) => true,
-            TypeCheckedExpr::GlobalVariableRef(_, _, _) => false,
-            TypeCheckedExpr::Variant(expr, _) => expr.is_pure(),
-            TypeCheckedExpr::FuncRef(_, func_type, _) => {
+        match &self.kind {
+            TypeCheckedExprKind::UnaryOp(_, expr, _) => expr.is_pure(),
+            TypeCheckedExprKind::Binary(_, left, right, _) => left.is_pure() && right.is_pure(),
+            TypeCheckedExprKind::ShortcutOr(left, right) => left.is_pure() && right.is_pure(),
+            TypeCheckedExprKind::ShortcutAnd(left, right) => left.is_pure() && right.is_pure(),
+            TypeCheckedExprKind::LocalVariableRef(_, _) => true,
+            TypeCheckedExprKind::GlobalVariableRef(_, _) => false,
+            TypeCheckedExprKind::Variant(expr) => expr.is_pure(),
+            TypeCheckedExprKind::FuncRef(_, func_type) => {
                 if let Type::Func(impure, _, _) = func_type {
                     !*impure
                 } else {
                     panic!("Internal error: func ref has non function type")
                 }
             }
-            TypeCheckedExpr::TupleRef(expr, _, _, _) => expr.is_pure(),
-            TypeCheckedExpr::DotRef(expr, _, _, _, _) => expr.is_pure(),
-            TypeCheckedExpr::Const(_, _, _) => true,
-            TypeCheckedExpr::FunctionCall(name_expr, fields_exprs, _, properties, _) => {
+            TypeCheckedExprKind::TupleRef(expr, _, _) => expr.is_pure(),
+            TypeCheckedExprKind::DotRef(expr, _, _, _) => expr.is_pure(),
+            TypeCheckedExprKind::Const(_, _) => true,
+            TypeCheckedExprKind::FunctionCall(name_expr, fields_exprs, _, properties) => {
                 name_expr.is_pure()
                     && fields_exprs.iter().all(|statement| statement.is_pure())
                     && properties.pure
             }
-            TypeCheckedExpr::CodeBlock(statements, return_expr, _, _) => {
+            TypeCheckedExprKind::CodeBlock(statements, return_expr, _) => {
                 statements.iter().all(|statement| statement.is_pure())
                     && return_expr
                         .as_ref()
                         .map(|expr| expr.is_pure())
                         .unwrap_or(true)
             }
-            TypeCheckedExpr::StructInitializer(fields, _, _) => {
+            TypeCheckedExprKind::StructInitializer(fields, _) => {
                 fields.iter().all(|field| field.value.is_pure())
             }
-            TypeCheckedExpr::ArrayRef(expr, expr2, _, _) => expr.is_pure() && expr2.is_pure(),
-            TypeCheckedExpr::FixedArrayRef(expr, expr2, _, _, _) => {
+            TypeCheckedExprKind::ArrayRef(expr, expr2, _) => expr.is_pure() && expr2.is_pure(),
+            TypeCheckedExprKind::FixedArrayRef(expr, expr2, _, _) => {
                 expr.is_pure() && expr2.is_pure()
             }
-            TypeCheckedExpr::MapRef(expr, expr2, _, _) => expr.is_pure() && expr2.is_pure(),
-            TypeCheckedExpr::Tuple(exprs, _, _) => exprs.iter().all(|expr| expr.is_pure()),
-            TypeCheckedExpr::NewArray(expr, _, _, _) => expr.is_pure(),
-            TypeCheckedExpr::NewFixedArray(_, opt_expr, _, _) => {
+            TypeCheckedExprKind::MapRef(expr, expr2, _) => expr.is_pure() && expr2.is_pure(),
+            TypeCheckedExprKind::Tuple(exprs, _) => exprs.iter().all(|expr| expr.is_pure()),
+            TypeCheckedExprKind::NewArray(expr, _, _) => expr.is_pure(),
+            TypeCheckedExprKind::NewFixedArray(_, opt_expr, _) => {
                 if let Some(expr) = opt_expr {
                     expr.is_pure()
                 } else {
                     true
                 }
             }
-            TypeCheckedExpr::NewMap(_, _) => true,
-            TypeCheckedExpr::ArrayMod(arr, index, val, _, _) => {
+            TypeCheckedExprKind::NewMap(_) => true,
+            TypeCheckedExprKind::ArrayMod(arr, index, val, _) => {
                 arr.is_pure() && index.is_pure() && val.is_pure()
             }
-            TypeCheckedExpr::FixedArrayMod(arr, index, val, _, _, _) => {
+            TypeCheckedExprKind::FixedArrayMod(arr, index, val, _, _) => {
                 arr.is_pure() && index.is_pure() && val.is_pure()
             }
-            TypeCheckedExpr::MapMod(map, key, val, _, _) => {
+            TypeCheckedExprKind::MapMod(map, key, val, _) => {
                 map.is_pure() && key.is_pure() && val.is_pure()
             }
-            TypeCheckedExpr::StructMod(the_struct, _, val, _, _) => {
+            TypeCheckedExprKind::StructMod(the_struct, _, val, _) => {
                 the_struct.is_pure() && val.is_pure()
             }
-            TypeCheckedExpr::Cast(expr, _, _) => expr.is_pure(),
-            TypeCheckedExpr::Asm(_, instrs, args, _) => {
+            TypeCheckedExprKind::Cast(expr, _) => expr.is_pure(),
+            TypeCheckedExprKind::Asm(_, instrs, args) => {
                 instrs.iter().all(|inst| inst.is_pure()) && args.iter().all(|expr| expr.is_pure())
             }
-            TypeCheckedExpr::Try(expr, _, _) => expr.is_pure(),
+            TypeCheckedExprKind::Try(expr, _) => expr.is_pure(),
         }
     }
 }
 
 impl AbstractSyntaxTree for TypeCheckedExpr {
     fn child_nodes(&mut self) -> Vec<TypeCheckedNode> {
-        match self {
-            TypeCheckedExpr::LocalVariableRef(_, _, _)
-            | TypeCheckedExpr::GlobalVariableRef(_, _, _)
-            | TypeCheckedExpr::FuncRef(_, _, _)
-            | TypeCheckedExpr::Const(_, _, _)
-            | TypeCheckedExpr::NewMap(_, _) => vec![],
-            TypeCheckedExpr::UnaryOp(_, exp, _, _)
-            | TypeCheckedExpr::Variant(exp, _)
-            | TypeCheckedExpr::TupleRef(exp, _, _, _)
-            | TypeCheckedExpr::DotRef(exp, _, _, _, _)
-            | TypeCheckedExpr::NewArray(exp, _, _, _)
-            | TypeCheckedExpr::Cast(exp, _, _)
-            | TypeCheckedExpr::Try(exp, _, _) => vec![TypeCheckedNode::Expression(exp)],
-            TypeCheckedExpr::Binary(_, lexp, rexp, _, _)
-            | TypeCheckedExpr::ShortcutOr(lexp, rexp, _)
-            | TypeCheckedExpr::ShortcutAnd(lexp, rexp, _)
-            | TypeCheckedExpr::ArrayRef(lexp, rexp, _, _)
-            | TypeCheckedExpr::FixedArrayRef(lexp, rexp, _, _, _)
-            | TypeCheckedExpr::MapRef(lexp, rexp, _, _)
-            | TypeCheckedExpr::StructMod(lexp, _, rexp, _, _) => vec![
+        match &mut self.kind {
+            TypeCheckedExprKind::LocalVariableRef(_, _)
+            | TypeCheckedExprKind::GlobalVariableRef(_, _)
+            | TypeCheckedExprKind::FuncRef(_, _)
+            | TypeCheckedExprKind::Const(_, _)
+            | TypeCheckedExprKind::NewMap(_) => vec![],
+            TypeCheckedExprKind::UnaryOp(_, exp, _)
+            | TypeCheckedExprKind::Variant(exp)
+            | TypeCheckedExprKind::TupleRef(exp, _, _)
+            | TypeCheckedExprKind::DotRef(exp, _, _, _)
+            | TypeCheckedExprKind::NewArray(exp, _, _)
+            | TypeCheckedExprKind::Cast(exp, _)
+            | TypeCheckedExprKind::Try(exp, _) => vec![TypeCheckedNode::Expression(exp)],
+            TypeCheckedExprKind::Binary(_, lexp, rexp, _)
+            | TypeCheckedExprKind::ShortcutOr(lexp, rexp)
+            | TypeCheckedExprKind::ShortcutAnd(lexp, rexp)
+            | TypeCheckedExprKind::ArrayRef(lexp, rexp, _)
+            | TypeCheckedExprKind::FixedArrayRef(lexp, rexp, _, _)
+            | TypeCheckedExprKind::MapRef(lexp, rexp, _)
+            | TypeCheckedExprKind::StructMod(lexp, _, rexp, _) => vec![
                 TypeCheckedNode::Expression(lexp),
                 TypeCheckedNode::Expression(rexp),
             ],
-            TypeCheckedExpr::FunctionCall(name_exp, arg_exps, _, _, _) => {
+            TypeCheckedExprKind::FunctionCall(name_exp, arg_exps, _, _) => {
                 vec![TypeCheckedNode::Expression(name_exp)]
                     .into_iter()
                     .chain(
@@ -574,7 +544,7 @@ impl AbstractSyntaxTree for TypeCheckedExpr {
                     )
                     .collect()
             }
-            TypeCheckedExpr::CodeBlock(stats, oexpr, _, _) => oexpr
+            TypeCheckedExprKind::CodeBlock(stats, oexpr, _) => oexpr
                 .iter_mut()
                 .map(|exp| TypeCheckedNode::Expression(exp))
                 .chain(
@@ -583,21 +553,21 @@ impl AbstractSyntaxTree for TypeCheckedExpr {
                         .map(|stat| TypeCheckedNode::Statement(stat)),
                 )
                 .collect(),
-            TypeCheckedExpr::StructInitializer(fields, _, _) => fields
+            TypeCheckedExprKind::StructInitializer(fields, _) => fields
                 .iter_mut()
                 .map(|field| TypeCheckedNode::StructField(field))
                 .collect(),
-            TypeCheckedExpr::Tuple(exps, _, _) | TypeCheckedExpr::Asm(_, _, exps, _) => exps
+            TypeCheckedExprKind::Tuple(exps, _) | TypeCheckedExprKind::Asm(_, _, exps) => exps
                 .iter_mut()
                 .map(|exp| TypeCheckedNode::Expression(exp))
                 .collect(),
-            TypeCheckedExpr::NewFixedArray(_, oexp, _, _) => oexp
+            TypeCheckedExprKind::NewFixedArray(_, oexp, _) => oexp
                 .into_iter()
                 .map(|exp| TypeCheckedNode::Expression(exp))
                 .collect(),
-            TypeCheckedExpr::ArrayMod(exp1, exp2, exp3, _, _)
-            | TypeCheckedExpr::FixedArrayMod(exp1, exp2, exp3, _, _, _)
-            | TypeCheckedExpr::MapMod(exp1, exp2, exp3, _, _) => vec![
+            TypeCheckedExprKind::ArrayMod(exp1, exp2, exp3, _)
+            | TypeCheckedExprKind::FixedArrayMod(exp1, exp2, exp3, _, _)
+            | TypeCheckedExprKind::MapMod(exp1, exp2, exp3, _) => vec![
                 TypeCheckedNode::Expression(exp1),
                 TypeCheckedNode::Expression(exp2),
                 TypeCheckedNode::Expression(exp3),
@@ -609,39 +579,39 @@ impl AbstractSyntaxTree for TypeCheckedExpr {
 impl TypeCheckedExpr {
     ///Extracts the type returned from the expression.
     pub fn get_type(&self) -> Type {
-        match self {
-            TypeCheckedExpr::UnaryOp(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::Binary(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::ShortcutOr(_, _, _) | TypeCheckedExpr::ShortcutAnd(_, _, _) => {
+        match &self.kind {
+            TypeCheckedExprKind::UnaryOp(_, _, t) => t.clone(),
+            TypeCheckedExprKind::Binary(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::ShortcutOr(_, _) | TypeCheckedExprKind::ShortcutAnd(_, _) => {
                 Type::Bool
             }
-            TypeCheckedExpr::LocalVariableRef(_, t, _) => t.clone(),
-            TypeCheckedExpr::GlobalVariableRef(_, t, _) => t.clone(),
-            TypeCheckedExpr::FuncRef(_, t, _) => t.clone(),
-            TypeCheckedExpr::TupleRef(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::Variant(t, _) => Type::Option(Box::new(t.get_type())),
-            TypeCheckedExpr::DotRef(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::Const(_, t, _) => t.clone(),
-            TypeCheckedExpr::FunctionCall(_, _, t, _, _) => t.clone(),
-            TypeCheckedExpr::CodeBlock(_, expr, _, _) => expr
+            TypeCheckedExprKind::LocalVariableRef(_, t) => t.clone(),
+            TypeCheckedExprKind::GlobalVariableRef(_, t) => t.clone(),
+            TypeCheckedExprKind::FuncRef(_, t) => t.clone(),
+            TypeCheckedExprKind::TupleRef(_, _, t) => t.clone(),
+            TypeCheckedExprKind::Variant(t) => Type::Option(Box::new(t.get_type())),
+            TypeCheckedExprKind::DotRef(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::Const(_, t) => t.clone(),
+            TypeCheckedExprKind::FunctionCall(_, _, t, _) => t.clone(),
+            TypeCheckedExprKind::CodeBlock(_, expr, _) => expr
                 .clone()
                 .map(|exp| exp.get_type())
                 .unwrap_or_else(|| Type::Tuple(vec![])),
-            TypeCheckedExpr::StructInitializer(_, t, _) => t.clone(),
-            TypeCheckedExpr::ArrayRef(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::FixedArrayRef(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::MapRef(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::Tuple(_, t, _) => t.clone(),
-            TypeCheckedExpr::NewArray(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::NewFixedArray(_, _, t, _) => t.clone(),
-            TypeCheckedExpr::NewMap(t, _) => t.clone(),
-            TypeCheckedExpr::ArrayMod(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::FixedArrayMod(_, _, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::MapMod(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::StructMod(_, _, _, t, _) => t.clone(),
-            TypeCheckedExpr::Cast(_, t, _) => t.clone(),
-            TypeCheckedExpr::Asm(t, _, _, _) => t.clone(),
-            TypeCheckedExpr::Try(_, t, _) => t.clone(),
+            TypeCheckedExprKind::StructInitializer(_, t) => t.clone(),
+            TypeCheckedExprKind::ArrayRef(_, _, t) => t.clone(),
+            TypeCheckedExprKind::FixedArrayRef(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::MapRef(_, _, t) => t.clone(),
+            TypeCheckedExprKind::Tuple(_, t) => t.clone(),
+            TypeCheckedExprKind::NewArray(_, _, t) => t.clone(),
+            TypeCheckedExprKind::NewFixedArray(_, _, t) => t.clone(),
+            TypeCheckedExprKind::NewMap(t) => t.clone(),
+            TypeCheckedExprKind::ArrayMod(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::FixedArrayMod(_, _, _, _, t) => t.clone(),
+            TypeCheckedExprKind::MapMod(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::StructMod(_, _, _, t) => t.clone(),
+            TypeCheckedExprKind::Cast(_, t) => t.clone(),
+            TypeCheckedExprKind::Asm(t, _, _) => t.clone(),
+            TypeCheckedExprKind::Try(_, t) => t.clone(),
         }
     }
 }
@@ -1499,417 +1469,625 @@ fn typecheck_expr(
     scopes: &mut Vec<(String, Option<Type>)>,
 ) -> Result<TypeCheckedExpr, TypeError> {
     let loc = expr.debug_info.location;
-    match &expr.kind {
-        ExprKind::UnaryOp(op, subexpr) => {
-            let tc_sub = typecheck_expr(
-                subexpr,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            typecheck_unary_op(*op, tc_sub, loc, type_tree)
-        }
-        ExprKind::Binary(op, sub1, sub2) => {
-            let tc_sub1 = typecheck_expr(
-                sub1,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_sub2 = typecheck_expr(
-                sub2,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            typecheck_binary_op(*op, tc_sub1, tc_sub2, type_tree, loc)
-        }
-        ExprKind::ShortcutOr(sub1, sub2) => {
-            let tc_sub1 = typecheck_expr(
-                sub1,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_sub2 = typecheck_expr(
-                sub2,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            if tc_sub1.get_type() != Type::Bool {
-                return Err(new_type_error(
-                    "operands to logical or must be boolean".to_string(),
-                    loc,
-                ));
+    Ok(TypeCheckedExpr {
+        kind: match &expr.kind {
+            ExprKind::UnaryOp(op, subexpr) => {
+                let tc_sub = typecheck_expr(
+                    subexpr,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                typecheck_unary_op(*op, tc_sub, loc, type_tree)
             }
-            if tc_sub2.get_type() != Type::Bool {
-                return Err(new_type_error(
-                    "operands to logical or must be boolean".to_string(),
-                    loc,
-                ));
+            ExprKind::Binary(op, sub1, sub2) => {
+                let tc_sub1 = typecheck_expr(
+                    sub1,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_sub2 = typecheck_expr(
+                    sub2,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                typecheck_binary_op(*op, tc_sub1, tc_sub2, type_tree, loc)
             }
-            Ok(TypeCheckedExpr::ShortcutOr(
-                Box::new(tc_sub1),
-                Box::new(tc_sub2),
-                loc,
-            ))
-        }
-        ExprKind::ShortcutAnd(sub1, sub2) => {
-            let tc_sub1 = typecheck_expr(
-                sub1,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_sub2 = typecheck_expr(
-                sub2,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            if tc_sub1.get_type() != Type::Bool {
-                return Err(new_type_error(
-                    "operands to logical and must be boolean".to_string(),
-                    loc,
-                ));
-            }
-            if tc_sub2.get_type() != Type::Bool {
-                return Err(new_type_error(
-                    "operands to logical and must be boolean".to_string(),
-                    loc,
-                ));
-            }
-            Ok(TypeCheckedExpr::ShortcutAnd(
-                Box::new(tc_sub1),
-                Box::new(tc_sub2),
-                loc,
-            ))
-        }
-        ExprKind::OptionInitializer(inner) => Ok(TypeCheckedExpr::Variant(
-            Box::new(typecheck_expr(
-                inner,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?),
-            loc,
-        )),
-        ExprKind::VariableRef(name) => match func_table.get(*name) {
-            Some(t) => Ok(TypeCheckedExpr::FuncRef(*name, t.clone(), loc)),
-            None => match type_table.get(*name) {
-                Some(t) => Ok(TypeCheckedExpr::LocalVariableRef(*name, t.clone(), loc)),
-                None => match global_vars.get(name) {
-                    Some((t, idx)) => Ok(TypeCheckedExpr::GlobalVariableRef(*idx, t.clone(), loc)),
-                    None => Err(new_type_error(
-                        "reference to unrecognized identifier".to_string(),
+            ExprKind::ShortcutOr(sub1, sub2) => {
+                let tc_sub1 = typecheck_expr(
+                    sub1,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_sub2 = typecheck_expr(
+                    sub2,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                if tc_sub1.get_type() != Type::Bool {
+                    return Err(new_type_error(
+                        "operands to logical or must be boolean".to_string(),
                         loc,
-                    )),
+                    ));
+                }
+                if tc_sub2.get_type() != Type::Bool {
+                    return Err(new_type_error(
+                        "operands to logical or must be boolean".to_string(),
+                        loc,
+                    ));
+                }
+                Ok(TypeCheckedExprKind::ShortcutOr(
+                    Box::new(tc_sub1),
+                    Box::new(tc_sub2),
+                ))
+            }
+            ExprKind::ShortcutAnd(sub1, sub2) => {
+                let tc_sub1 = typecheck_expr(
+                    sub1,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_sub2 = typecheck_expr(
+                    sub2,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                if tc_sub1.get_type() != Type::Bool {
+                    return Err(new_type_error(
+                        "operands to logical and must be boolean".to_string(),
+                        loc,
+                    ));
+                }
+                if tc_sub2.get_type() != Type::Bool {
+                    return Err(new_type_error(
+                        "operands to logical and must be boolean".to_string(),
+                        loc,
+                    ));
+                }
+                Ok(TypeCheckedExprKind::ShortcutAnd(
+                    Box::new(tc_sub1),
+                    Box::new(tc_sub2),
+                ))
+            }
+            ExprKind::OptionInitializer(inner) => {
+                Ok(TypeCheckedExprKind::Variant(Box::new(typecheck_expr(
+                    inner,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?)))
+            }
+            ExprKind::VariableRef(name) => match func_table.get(*name) {
+                Some(t) => Ok(TypeCheckedExprKind::FuncRef(*name, t.clone())),
+                None => match type_table.get(*name) {
+                    Some(t) => Ok(TypeCheckedExprKind::LocalVariableRef(*name, t.clone())),
+                    None => match global_vars.get(name) {
+                        Some((t, idx)) => {
+                            Ok(TypeCheckedExprKind::GlobalVariableRef(*idx, t.clone()))
+                        }
+                        None => Err(new_type_error(
+                            "reference to unrecognized identifier".to_string(),
+                            loc,
+                        )),
+                    },
                 },
             },
-        },
-        ExprKind::TupleRef(tref, idx) => {
-            let tc_sub = typecheck_expr(
-                &*tref,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let uidx = idx.to_usize().unwrap();
-            if let Type::Tuple(tv) = tc_sub.get_type() {
-                if uidx < tv.len() {
-                    Ok(TypeCheckedExpr::TupleRef(
-                        Box::new(tc_sub),
-                        idx.clone(),
-                        tv[uidx].clone(),
+            ExprKind::TupleRef(tref, idx) => {
+                let tc_sub = typecheck_expr(
+                    &*tref,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let uidx = idx.to_usize().unwrap();
+                if let Type::Tuple(tv) = tc_sub.get_type() {
+                    if uidx < tv.len() {
+                        Ok(TypeCheckedExprKind::TupleRef(
+                            Box::new(tc_sub),
+                            idx.clone(),
+                            tv[uidx].clone(),
+                        ))
+                    } else {
+                        Err(new_type_error(
+                            "tuple field access to non-existent field".to_string(),
+                            loc,
+                        ))
+                    }
+                } else {
+                    Err(new_type_error(
+                        "tuple field access to non-tuple value".to_string(),
+                        loc,
+                    ))
+                }
+            }
+            ExprKind::DotRef(sref, name) => {
+                let tc_sub = typecheck_expr(
+                    &*sref,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                if let Type::Struct(v) = tc_sub.get_type().get_representation(type_tree)? {
+                    for sf in v.iter() {
+                        if *name == sf.name {
+                            let slot_num = tc_sub
+                                .get_type()
+                                .get_representation(type_tree)?
+                                .get_struct_slot_by_name(name.clone())
+                                .ok_or(new_type_error(
+                                    "Could not find name of struct field".to_string(),
+                                    loc,
+                                ))?;
+                            return Ok(TypeCheckedExpr {
+                                kind: TypeCheckedExprKind::DotRef(
+                                    Box::new(tc_sub),
+                                    slot_num,
+                                    v.len(),
+                                    sf.tipe.clone(),
+                                ),
+                                debug_info: DebugInfo { location: loc },
+                            });
+                        }
+                    }
+                    Err(new_type_error(
+                        "reference to non-existent struct field".to_string(),
                         loc,
                     ))
                 } else {
                     Err(new_type_error(
-                        "tuple field access to non-existent field".to_string(),
+                        "struct field access to non-struct value".to_string(),
                         loc,
                     ))
                 }
-            } else {
-                Err(new_type_error(
-                    "tuple field access to non-tuple value".to_string(),
-                    loc,
-                ))
             }
-        }
-        ExprKind::DotRef(sref, name) => {
-            let tc_sub = typecheck_expr(
-                &*sref,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            if let Type::Struct(v) = tc_sub.get_type().get_representation(type_tree)? {
-                for sf in v.iter() {
-                    if *name == sf.name {
-                        let slot_num = tc_sub
-                            .get_type()
-                            .get_representation(type_tree)?
-                            .get_struct_slot_by_name(name.clone())
-                            .ok_or(new_type_error(
-                                "Could not find name of struct field".to_string(),
+            ExprKind::Constant(constant) => Ok(match constant {
+                Constant::Uint(n) => TypeCheckedExprKind::Const(Value::Int(n.clone()), Type::Uint),
+                Constant::Int(n) => TypeCheckedExprKind::Const(Value::Int(n.clone()), Type::Int),
+                Constant::Bool(b) => {
+                    TypeCheckedExprKind::Const(Value::Int(Uint256::from_bool(*b)), Type::Bool)
+                }
+                Constant::Option(o) => TypeCheckedExprKind::Const(o.value(), o.type_of()),
+                Constant::Null => TypeCheckedExprKind::Const(Value::none(), Type::Any),
+            }),
+            ExprKind::FunctionCall(fexpr, args) => {
+                let tc_fexpr = typecheck_expr(
+                    fexpr,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                match tc_fexpr.get_type().get_representation(type_tree)? {
+                    Type::Func(impure, arg_types, ret_type) => {
+                        let ret_type = ret_type.resolve_types(type_table, loc)?;
+                        if args.len() == arg_types.len() {
+                            let mut tc_args = Vec::new();
+                            for i in 0..args.len() {
+                                let tc_arg = typecheck_expr(
+                                    &args[i],
+                                    type_table,
+                                    global_vars,
+                                    func_table,
+                                    return_type,
+                                    type_tree,
+                                    scopes,
+                                )?;
+                                tc_args.push(tc_arg);
+                                let resolved_arg_type =
+                                    arg_types[i].resolve_types(&type_table, loc)?;
+                                if !resolved_arg_type.assignable(
+                                    &tc_args[i].get_type().get_representation(type_tree)?,
+                                    type_tree,
+                                ) {
+                                    println!(
+                                        "expected {:?}",
+                                        resolved_arg_type.get_representation(type_tree)?
+                                    );
+                                    println!(
+                                        "actual   {:?}",
+                                        tc_args[i].get_type().get_representation(type_tree)?
+                                    );
+                                    return Err(new_type_error(
+                                        "wrong argument type in function call".to_string(),
+                                        loc,
+                                    ));
+                                }
+                            }
+                            Ok(TypeCheckedExprKind::FunctionCall(
+                                Box::new(tc_fexpr),
+                                tc_args,
+                                ret_type,
+                                PropertiesList { pure: !impure },
+                            ))
+                        } else {
+                            Err(new_type_error(
+                                "wrong number of args passed to function".to_string(),
                                 loc,
-                            ))?;
-                        return Ok(TypeCheckedExpr::DotRef(
-                            Box::new(tc_sub),
-                            slot_num,
-                            v.len(),
-                            sf.tipe.clone(),
-                            loc,
-                        ));
+                            ))
+                        }
+                    }
+                    _ => Err(new_type_error(
+                        "function call to value that is not a function".to_string(),
+                        loc,
+                    )),
+                }
+            }
+            ExprKind::CodeBlock(body, ret_expr) => {
+                let mut output = Vec::new();
+                let mut block_bindings = Vec::new();
+                scopes.push(("_".to_string(), None));
+                for statement in body {
+                    let inner_type_table = type_table
+                        .push_multi(block_bindings.iter().map(|(k, v)| (*k, v)).collect());
+                    let (statement, bindings) = typecheck_statement(
+                        &statement.kind,
+                        &loc,
+                        return_type,
+                        &inner_type_table,
+                        global_vars,
+                        func_table,
+                        type_tree,
+                        scopes,
+                    )?;
+                    output.push(statement);
+                    for (key, value) in bindings {
+                        block_bindings.push((key, value));
                     }
                 }
-                Err(new_type_error(
-                    "reference to non-existent struct field".to_string(),
-                    loc,
-                ))
-            } else {
-                Err(new_type_error(
-                    "struct field access to non-struct value".to_string(),
-                    loc,
-                ))
-            }
-        }
-        ExprKind::Constant(constant) => Ok(match constant {
-            Constant::Uint(n) => TypeCheckedExpr::Const(Value::Int(n.clone()), Type::Uint, loc),
-            Constant::Int(n) => TypeCheckedExpr::Const(Value::Int(n.clone()), Type::Int, loc),
-            Constant::Bool(b) => {
-                TypeCheckedExpr::Const(Value::Int(Uint256::from_bool(*b)), Type::Bool, loc)
-            }
-            Constant::Option(o) => TypeCheckedExpr::Const(o.value(), o.type_of(), loc),
-            Constant::Null => TypeCheckedExpr::Const(Value::none(), Type::Any, loc),
-        }),
-        ExprKind::FunctionCall(fexpr, args) => {
-            let tc_fexpr = typecheck_expr(
-                fexpr,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            match tc_fexpr.get_type().get_representation(type_tree)? {
-                Type::Func(impure, arg_types, ret_type) => {
-                    let ret_type = ret_type.resolve_types(type_table, loc)?;
-                    if args.len() == arg_types.len() {
-                        let mut tc_args = Vec::new();
-                        for i in 0..args.len() {
-                            let tc_arg = typecheck_expr(
-                                &args[i],
-                                type_table,
+                let inner_type_table =
+                    type_table.push_multi(block_bindings.iter().map(|(k, v)| (*k, v)).collect());
+                Ok(TypeCheckedExprKind::CodeBlock(
+                    output,
+                    ret_expr
+                        .clone()
+                        .map(|x| {
+                            typecheck_expr(
+                                &*x,
+                                &inner_type_table,
                                 global_vars,
                                 func_table,
                                 return_type,
                                 type_tree,
                                 scopes,
-                            )?;
-                            tc_args.push(tc_arg);
-                            let resolved_arg_type = arg_types[i].resolve_types(&type_table, loc)?;
-                            if !resolved_arg_type.assignable(
-                                &tc_args[i].get_type().get_representation(type_tree)?,
-                                type_tree,
-                            ) {
-                                println!(
-                                    "expected {:?}",
-                                    resolved_arg_type.get_representation(type_tree)?
-                                );
-                                println!(
-                                    "actual   {:?}",
-                                    tc_args[i].get_type().get_representation(type_tree)?
-                                );
-                                return Err(new_type_error(
-                                    "wrong argument type in function call".to_string(),
-                                    loc,
-                                ));
-                            }
-                        }
-                        Ok(TypeCheckedExpr::FunctionCall(
-                            Box::new(tc_fexpr),
-                            tc_args,
-                            ret_type,
-                            PropertiesList { pure: !impure },
-                            loc,
-                        ))
-                    } else {
-                        Err(new_type_error(
-                            "wrong number of args passed to function".to_string(),
-                            loc,
-                        ))
-                    }
-                }
-                _ => Err(new_type_error(
-                    "function call to value that is not a function".to_string(),
-                    loc,
-                )),
+                            )
+                        })
+                        .transpose()?
+                        .map(Box::new),
+                    None,
+                ))
             }
-        }
-        ExprKind::CodeBlock(body, ret_expr) => {
-            let mut output = Vec::new();
-            let mut block_bindings = Vec::new();
-            scopes.push(("_".to_string(), None));
-            for statement in body {
-                let inner_type_table =
-                    type_table.push_multi(block_bindings.iter().map(|(k, v)| (*k, v)).collect());
-                let (statement, bindings) = typecheck_statement(
-                    &statement.kind,
-                    &loc,
-                    return_type,
-                    &inner_type_table,
+            ExprKind::ArrayOrMapRef(array, index) => {
+                let tc_arr = typecheck_expr(
+                    &*array,
+                    type_table,
                     global_vars,
                     func_table,
+                    return_type,
                     type_tree,
                     scopes,
                 )?;
-                output.push(statement);
-                for (key, value) in bindings {
-                    block_bindings.push((key, value));
+                let tc_idx = typecheck_expr(
+                    &*index,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                match tc_arr.get_type().get_representation(type_tree)? {
+                    Type::Array(t) => {
+                        if tc_idx.get_type() == Type::Uint {
+                            Ok(TypeCheckedExprKind::ArrayRef(
+                                Box::new(tc_arr),
+                                Box::new(tc_idx),
+                                *t,
+                            ))
+                        } else {
+                            Err(new_type_error("array index must be Uint".to_string(), loc))
+                        }
+                    }
+                    Type::FixedArray(t, sz) => {
+                        if tc_idx.get_type() == Type::Uint {
+                            Ok(TypeCheckedExprKind::FixedArrayRef(
+                                Box::new(tc_arr),
+                                Box::new(tc_idx),
+                                sz,
+                                *t,
+                            ))
+                        } else {
+                            Err(new_type_error(
+                                "fixedarray index must be Uint".to_string(),
+                                loc,
+                            ))
+                        }
+                    }
+                    Type::Map(kt, vt) => {
+                        if tc_idx.get_type() == *kt {
+                            Ok(TypeCheckedExprKind::MapRef(
+                                Box::new(tc_arr),
+                                Box::new(tc_idx),
+                                Type::Option(Box::new(*vt)),
+                            ))
+                        } else {
+                            Err(new_type_error(
+                                "invalid key value in map lookup".to_string(),
+                                loc,
+                            ))
+                        }
+                    }
+                    _ => Err(new_type_error(
+                        "fixedarray lookup in non-array type".to_string(),
+                        loc,
+                    )),
                 }
             }
-            let inner_type_table =
-                type_table.push_multi(block_bindings.iter().map(|(k, v)| (*k, v)).collect());
-            Ok(TypeCheckedExpr::CodeBlock(
-                output,
-                ret_expr
-                    .clone()
-                    .map(|x| {
-                        typecheck_expr(
-                            &*x,
-                            &inner_type_table,
-                            global_vars,
-                            func_table,
-                            return_type,
-                            type_tree,
-                            scopes,
-                        )
-                    })
-                    .transpose()?
-                    .map(Box::new),
-                None,
-                loc,
-            ))
-        }
-        ExprKind::ArrayOrMapRef(array, index) => {
-            let tc_arr = typecheck_expr(
-                &*array,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_idx = typecheck_expr(
-                &*index,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            match tc_arr.get_type().get_representation(type_tree)? {
-                Type::Array(t) => {
-                    if tc_idx.get_type() == Type::Uint {
-                        Ok(TypeCheckedExpr::ArrayRef(
-                            Box::new(tc_arr),
-                            Box::new(tc_idx),
-                            *t,
-                            loc,
-                        ))
-                    } else {
-                        Err(new_type_error("array index must be Uint".to_string(), loc))
-                    }
+            ExprKind::NewArray(size_expr, tipe) => Ok(TypeCheckedExprKind::NewArray(
+                Box::new(typecheck_expr(
+                    size_expr,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?),
+                tipe.get_representation(type_tree)?,
+                Type::Array(Box::new(tipe.clone())),
+            )),
+            ExprKind::NewFixedArray(size, maybe_expr) => match maybe_expr {
+                Some(expr) => {
+                    let tc_expr = typecheck_expr(
+                        expr,
+                        type_table,
+                        global_vars,
+                        func_table,
+                        return_type,
+                        type_tree,
+                        scopes,
+                    )?;
+                    Ok(TypeCheckedExprKind::NewFixedArray(
+                        *size,
+                        Some(Box::new(tc_expr.clone())),
+                        Type::FixedArray(Box::new(tc_expr.get_type()), *size),
+                    ))
                 }
-                Type::FixedArray(t, sz) => {
-                    if tc_idx.get_type() == Type::Uint {
-                        Ok(TypeCheckedExpr::FixedArrayRef(
-                            Box::new(tc_arr),
-                            Box::new(tc_idx),
-                            sz,
-                            *t,
-                            loc,
-                        ))
-                    } else {
-                        Err(new_type_error(
-                            "fixedarray index must be Uint".to_string(),
-                            loc,
-                        ))
-                    }
-                }
-                Type::Map(kt, vt) => {
-                    if tc_idx.get_type() == *kt {
-                        Ok(TypeCheckedExpr::MapRef(
-                            Box::new(tc_arr),
-                            Box::new(tc_idx),
-                            Type::Option(Box::new(*vt)),
-                            loc,
-                        ))
-                    } else {
-                        Err(new_type_error(
-                            "invalid key value in map lookup".to_string(),
-                            loc,
-                        ))
-                    }
-                }
-                _ => Err(new_type_error(
-                    "fixedarray lookup in non-array type".to_string(),
-                    loc,
+                None => Ok(TypeCheckedExprKind::NewFixedArray(
+                    *size,
+                    None,
+                    Type::FixedArray(Box::new(Type::Any), *size),
                 )),
+            },
+            ExprKind::NewMap(key_type, value_type) => Ok(TypeCheckedExprKind::NewMap(Type::Map(
+                Box::new(key_type.clone()),
+                Box::new(value_type.clone()),
+            ))),
+            ExprKind::StructInitializer(fieldvec) => {
+                let mut tc_fields = Vec::new();
+                let mut tc_fieldtypes = Vec::new();
+                for field in fieldvec {
+                    let tc_expr = typecheck_expr(
+                        &field.value,
+                        type_table,
+                        global_vars,
+                        func_table,
+                        return_type,
+                        type_tree,
+                        scopes,
+                    )?;
+                    tc_fields.push(TypeCheckedStructField::new(
+                        field.name.clone(),
+                        tc_expr.clone(),
+                    ));
+                    tc_fieldtypes.push(StructField::new(field.name.clone(), tc_expr.get_type()));
+                }
+                Ok(TypeCheckedExprKind::StructInitializer(
+                    tc_fields,
+                    Type::Struct(tc_fieldtypes),
+                ))
             }
-        }
-        ExprKind::NewArray(size_expr, tipe) => Ok(TypeCheckedExpr::NewArray(
-            Box::new(typecheck_expr(
-                size_expr,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?),
-            tipe.get_representation(type_tree)?,
-            Type::Array(Box::new(tipe.clone())),
-            loc,
-        )),
-        ExprKind::NewFixedArray(size, maybe_expr) => match maybe_expr {
-            Some(expr) => {
-                let tc_expr = typecheck_expr(
+            ExprKind::Tuple(fields) => {
+                let mut tc_fields = Vec::new();
+                let mut types = Vec::new();
+                for field in fields {
+                    let tc_field = typecheck_expr(
+                        field,
+                        type_table,
+                        global_vars,
+                        func_table,
+                        return_type,
+                        type_tree,
+                        scopes,
+                    )?;
+                    types.push(tc_field.get_type().clone());
+                    tc_fields.push(tc_field);
+                }
+                Ok(TypeCheckedExprKind::Tuple(tc_fields, Type::Tuple(types)))
+            }
+            ExprKind::ArrayOrMapMod(arr, index, val) => {
+                let tc_arr = typecheck_expr(
+                    arr,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_index = typecheck_expr(
+                    index,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_val = typecheck_expr(
+                    val,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                match tc_arr.get_type().get_representation(type_tree)? {
+                    Type::Array(t) => {
+                        if t.assignable(&tc_val.get_type(), type_tree) {
+                            if tc_index.get_type() != Type::Uint {
+                                Err(new_type_error(
+                                    "array modifier requires uint index".to_string(),
+                                    loc,
+                                ))
+                            } else {
+                                Ok(TypeCheckedExprKind::ArrayMod(
+                                    Box::new(tc_arr),
+                                    Box::new(tc_index),
+                                    Box::new(tc_val),
+                                    Type::Array(t),
+                                ))
+                            }
+                        } else {
+                            Err(new_type_error(
+                                "mismatched types in array modifier".to_string(),
+                                loc,
+                            ))
+                        }
+                    }
+                    Type::FixedArray(t, sz) => {
+                        if tc_index.get_type() != Type::Uint {
+                            Err(new_type_error(
+                                "array modifier requires uint index".to_string(),
+                                loc,
+                            ))
+                        } else {
+                            Ok(TypeCheckedExprKind::FixedArrayMod(
+                                Box::new(tc_arr),
+                                Box::new(tc_index),
+                                Box::new(tc_val),
+                                sz,
+                                Type::FixedArray(t, sz),
+                            ))
+                        }
+                    }
+                    Type::Map(kt, vt) => {
+                        if tc_index.get_type() == *kt {
+                            if vt.assignable(&tc_val.get_type(), type_tree) {
+                                Ok(TypeCheckedExprKind::MapMod(
+                                    Box::new(tc_arr),
+                                    Box::new(tc_index),
+                                    Box::new(tc_val),
+                                    Type::Map(kt, vt),
+                                ))
+                            } else {
+                                Err(new_type_error(
+                                    "invalid value type for map modifier".to_string(),
+                                    loc,
+                                ))
+                            }
+                        } else {
+                            Err(new_type_error(
+                                "invalid key type for map modifier".to_string(),
+                                loc,
+                            ))
+                        }
+                    }
+                    _ => Err(new_type_error(
+                        "[] modifier must operate on array or block".to_string(),
+                        loc,
+                    )),
+                }
+            }
+            ExprKind::StructMod(struc, name, val) => {
+                let tc_struc = typecheck_expr(
+                    struc,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tc_val = typecheck_expr(
+                    val,
+                    type_table,
+                    global_vars,
+                    func_table,
+                    return_type,
+                    type_tree,
+                    scopes,
+                )?;
+                let tcs_type = tc_struc.get_type().get_representation(type_tree)?;
+                if let Type::Struct(fields) = &tcs_type {
+                    match tcs_type.get_struct_slot_by_name(name.clone()) {
+                        Some(index) => {
+                            if fields[index].tipe.assignable(&tc_val.get_type(), type_tree) {
+                                Ok(TypeCheckedExprKind::StructMod(
+                                    Box::new(tc_struc),
+                                    index,
+                                    Box::new(tc_val),
+                                    tcs_type,
+                                ))
+                            } else {
+                                Err(new_type_error(
+                                    "incorrect value type in struct modifier".to_string(),
+                                    loc,
+                                ))
+                            }
+                        }
+                        None => Err(new_type_error(
+                            "struct modifier must use valid field name".to_string(),
+                            loc,
+                        )),
+                    }
+                } else {
+                    Err(new_type_error(
+                        "struct modifier must operate on a struct".to_string(),
+                        loc,
+                    ))
+                }
+            }
+            ExprKind::UnsafeCast(expr, t) => Ok(TypeCheckedExprKind::Cast(
+                Box::new(typecheck_expr(
                     expr,
                     type_table,
                     global_vars,
@@ -1917,31 +2095,47 @@ fn typecheck_expr(
                     return_type,
                     type_tree,
                     scopes,
-                )?;
-                Ok(TypeCheckedExpr::NewFixedArray(
-                    *size,
-                    Some(Box::new(tc_expr.clone())),
-                    Type::FixedArray(Box::new(tc_expr.get_type()), *size),
-                    loc,
+                )?),
+                t.clone(),
+            )),
+            ExprKind::Asm(ret_type, insns, args) => {
+                if *ret_type == Type::Void {
+                    return Err(new_type_error(
+                        "asm expression cannot return void".to_string(),
+                        loc,
+                    ));
+                }
+                let mut tc_args = Vec::new();
+                for arg in args {
+                    tc_args.push(typecheck_expr(
+                        arg,
+                        type_table,
+                        global_vars,
+                        func_table,
+                        return_type,
+                        type_tree,
+                        scopes,
+                    )?);
+                }
+                Ok(TypeCheckedExprKind::Asm(
+                    ret_type.clone(),
+                    insns.to_vec(),
+                    tc_args,
                 ))
             }
-            None => Ok(TypeCheckedExpr::NewFixedArray(
-                *size,
-                None,
-                Type::FixedArray(Box::new(Type::Any), *size),
-                loc,
-            )),
-        },
-        ExprKind::NewMap(key_type, value_type) => Ok(TypeCheckedExpr::NewMap(
-            Type::Map(Box::new(key_type.clone()), Box::new(value_type.clone())),
-            loc,
-        )),
-        ExprKind::StructInitializer(fieldvec) => {
-            let mut tc_fields = Vec::new();
-            let mut tc_fieldtypes = Vec::new();
-            for field in fieldvec {
-                let tc_expr = typecheck_expr(
-                    &field.value,
+            ExprKind::Try(inner) => {
+                match return_type {
+                    Type::Option(_) | Type::Any => {}
+                    _ => {
+                        return Err(new_type_error(
+                            "Can only use \"?\" operator in functions that can return option"
+                                .to_string(),
+                            loc,
+                        ))
+                    }
+                }
+                let res = typecheck_expr(
+                    inner,
                     type_table,
                     global_vars,
                     func_table,
@@ -1949,252 +2143,17 @@ fn typecheck_expr(
                     type_tree,
                     scopes,
                 )?;
-                tc_fields.push(TypeCheckedStructField::new(
-                    field.name.clone(),
-                    tc_expr.clone(),
-                ));
-                tc_fieldtypes.push(StructField::new(field.name.clone(), tc_expr.get_type()));
-            }
-            Ok(TypeCheckedExpr::StructInitializer(
-                tc_fields,
-                Type::Struct(tc_fieldtypes),
-                loc,
-            ))
-        }
-        ExprKind::Tuple(fields) => {
-            let mut tc_fields = Vec::new();
-            let mut types = Vec::new();
-            for field in fields {
-                let tc_field = typecheck_expr(
-                    field,
-                    type_table,
-                    global_vars,
-                    func_table,
-                    return_type,
-                    type_tree,
-                    scopes,
-                )?;
-                types.push(tc_field.get_type().clone());
-                tc_fields.push(tc_field);
-            }
-            Ok(TypeCheckedExpr::Tuple(tc_fields, Type::Tuple(types), loc))
-        }
-        ExprKind::ArrayOrMapMod(arr, index, val) => {
-            let tc_arr = typecheck_expr(
-                arr,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_index = typecheck_expr(
-                index,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_val = typecheck_expr(
-                val,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            match tc_arr.get_type().get_representation(type_tree)? {
-                Type::Array(t) => {
-                    if t.assignable(&tc_val.get_type(), type_tree) {
-                        if tc_index.get_type() != Type::Uint {
-                            Err(new_type_error(
-                                "array modifier requires uint index".to_string(),
-                                loc,
-                            ))
-                        } else {
-                            Ok(TypeCheckedExpr::ArrayMod(
-                                Box::new(tc_arr),
-                                Box::new(tc_index),
-                                Box::new(tc_val),
-                                Type::Array(t),
-                                loc,
-                            ))
-                        }
-                    } else {
-                        Err(new_type_error(
-                            "mismatched types in array modifier".to_string(),
-                            loc,
-                        ))
-                    }
-                }
-                Type::FixedArray(t, sz) => {
-                    if tc_index.get_type() != Type::Uint {
-                        Err(new_type_error(
-                            "array modifier requires uint index".to_string(),
-                            loc,
-                        ))
-                    } else {
-                        Ok(TypeCheckedExpr::FixedArrayMod(
-                            Box::new(tc_arr),
-                            Box::new(tc_index),
-                            Box::new(tc_val),
-                            sz,
-                            Type::FixedArray(t, sz),
-                            loc,
-                        ))
-                    }
-                }
-                Type::Map(kt, vt) => {
-                    if tc_index.get_type() == *kt {
-                        if vt.assignable(&tc_val.get_type(), type_tree) {
-                            Ok(TypeCheckedExpr::MapMod(
-                                Box::new(tc_arr),
-                                Box::new(tc_index),
-                                Box::new(tc_val),
-                                Type::Map(kt, vt),
-                                loc,
-                            ))
-                        } else {
-                            Err(new_type_error(
-                                "invalid value type for map modifier".to_string(),
-                                loc,
-                            ))
-                        }
-                    } else {
-                        Err(new_type_error(
-                            "invalid key type for map modifier".to_string(),
-                            loc,
-                        ))
-                    }
-                }
-                _ => Err(new_type_error(
-                    "[] modifier must operate on array or block".to_string(),
-                    loc,
-                )),
-            }
-        }
-        ExprKind::StructMod(struc, name, val) => {
-            let tc_struc = typecheck_expr(
-                struc,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tc_val = typecheck_expr(
-                val,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            let tcs_type = tc_struc.get_type().get_representation(type_tree)?;
-            if let Type::Struct(fields) = &tcs_type {
-                match tcs_type.get_struct_slot_by_name(name.clone()) {
-                    Some(index) => {
-                        if fields[index].tipe.assignable(&tc_val.get_type(), type_tree) {
-                            Ok(TypeCheckedExpr::StructMod(
-                                Box::new(tc_struc),
-                                index,
-                                Box::new(tc_val),
-                                tcs_type,
-                                loc,
-                            ))
-                        } else {
-                            Err(new_type_error(
-                                "incorrect value type in struct modifier".to_string(),
-                                loc,
-                            ))
-                        }
-                    }
-                    None => Err(new_type_error(
-                        "struct modifier must use valid field name".to_string(),
+                match res.get_type().get_representation(type_tree)? {
+                    Type::Option(t) => Ok(TypeCheckedExprKind::Try(Box::new(res), *t)),
+                    other => Err(new_type_error(
+                        format!("Try expression requires option type, found \"{:?}\"", other),
                         loc,
                     )),
                 }
-            } else {
-                Err(new_type_error(
-                    "struct modifier must operate on a struct".to_string(),
-                    loc,
-                ))
             }
-        }
-        ExprKind::UnsafeCast(expr, t) => Ok(TypeCheckedExpr::Cast(
-            Box::new(typecheck_expr(
-                expr,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?),
-            t.clone(),
-            loc,
-        )),
-        ExprKind::Asm(ret_type, insns, args) => {
-            if *ret_type == Type::Void {
-                return Err(new_type_error(
-                    "asm expression cannot return void".to_string(),
-                    loc,
-                ));
-            }
-            let mut tc_args = Vec::new();
-            for arg in args {
-                tc_args.push(typecheck_expr(
-                    arg,
-                    type_table,
-                    global_vars,
-                    func_table,
-                    return_type,
-                    type_tree,
-                    scopes,
-                )?);
-            }
-            Ok(TypeCheckedExpr::Asm(
-                ret_type.clone(),
-                insns.to_vec(),
-                tc_args,
-                loc,
-            ))
-        }
-        ExprKind::Try(inner) => {
-            match return_type {
-                Type::Option(_) | Type::Any => {}
-                _ => {
-                    return Err(new_type_error(
-                        "Can only use \"?\" operator in functions that can return option"
-                            .to_string(),
-                        loc,
-                    ))
-                }
-            }
-            let res = typecheck_expr(
-                inner,
-                type_table,
-                global_vars,
-                func_table,
-                return_type,
-                type_tree,
-                scopes,
-            )?;
-            match res.get_type().get_representation(type_tree)? {
-                Type::Option(t) => Ok(TypeCheckedExpr::Try(Box::new(res), *t, loc)),
-                other => Err(new_type_error(
-                    format!("Try expression requires option type, found \"{:?}\"", other),
-                    loc,
-                )),
-            }
-        }
-    }
+        }?,
+        debug_info: DebugInfo { location: loc },
+    })
 }
 
 ///Attempts to apply the `UnaryOp` op, to `TypeCheckedExpr` sub_expr, producing a `TypeCheckedExpr`
@@ -2205,23 +2164,21 @@ fn typecheck_unary_op(
     sub_expr: TypeCheckedExpr,
     loc: Option<Location>,
     type_tree: &TypeTree,
-) -> Result<TypeCheckedExpr, TypeError> {
+) -> Result<TypeCheckedExprKind, TypeError> {
     let tc_type = sub_expr.get_type().get_representation(type_tree)?;
     match op {
         UnaryOp::Minus => match tc_type {
             Type::Int => {
-                if let TypeCheckedExpr::Const(Value::Int(ui), _, loc) = sub_expr {
-                    Ok(TypeCheckedExpr::Const(
+                if let TypeCheckedExprKind::Const(Value::Int(ui), _) = sub_expr.kind {
+                    Ok(TypeCheckedExprKind::Const(
                         Value::Int(ui.unary_minus().unwrap()),
                         Type::Int,
-                        loc,
                     ))
                 } else {
-                    Ok(TypeCheckedExpr::UnaryOp(
+                    Ok(TypeCheckedExprKind::UnaryOp(
                         UnaryOp::Minus,
                         Box::new(sub_expr),
                         Type::Int,
-                        loc,
                     ))
                 }
             }
@@ -2231,12 +2188,11 @@ fn typecheck_unary_op(
             )),
         },
         UnaryOp::BitwiseNeg => {
-            if let TypeCheckedExpr::Const(Value::Int(ui), _, loc) = sub_expr {
+            if let TypeCheckedExprKind::Const(Value::Int(ui), _) = sub_expr.kind {
                 match tc_type {
-                    Type::Uint | Type::Int | Type::Bytes32 => Ok(TypeCheckedExpr::Const(
+                    Type::Uint | Type::Int | Type::Bytes32 => Ok(TypeCheckedExprKind::Const(
                         Value::Int(ui.bitwise_neg()),
                         tc_type,
-                        loc,
                     )),
                     _ => Err(new_type_error(
                         "invalid operand type for bitwise negation".to_string(),
@@ -2245,11 +2201,10 @@ fn typecheck_unary_op(
                 }
             } else {
                 match tc_type {
-                    Type::Uint | Type::Int | Type::Bytes32 => Ok(TypeCheckedExpr::UnaryOp(
+                    Type::Uint | Type::Int | Type::Bytes32 => Ok(TypeCheckedExprKind::UnaryOp(
                         UnaryOp::BitwiseNeg,
                         Box::new(sub_expr),
                         tc_type,
-                        loc,
                     )),
                     _ => Err(new_type_error(
                         "invalid operand type for bitwise negation".to_string(),
@@ -2260,19 +2215,17 @@ fn typecheck_unary_op(
         }
         UnaryOp::Not => match tc_type {
             Type::Bool => {
-                if let TypeCheckedExpr::Const(Value::Int(ui), _, loc) = sub_expr {
+                if let TypeCheckedExprKind::Const(Value::Int(ui), _) = sub_expr.kind {
                     let b = ui.to_usize().unwrap();
-                    Ok(TypeCheckedExpr::Const(
+                    Ok(TypeCheckedExprKind::Const(
                         Value::Int(Uint256::from_usize(1 - b)),
                         Type::Bool,
-                        loc,
                     ))
                 } else {
-                    Ok(TypeCheckedExpr::UnaryOp(
+                    Ok(TypeCheckedExprKind::UnaryOp(
                         UnaryOp::Not,
                         Box::new(sub_expr),
                         Type::Bool,
-                        loc,
                     ))
                 }
             }
@@ -2282,37 +2235,32 @@ fn typecheck_unary_op(
             )),
         },
         UnaryOp::Hash => {
-            if let TypeCheckedExpr::Const(Value::Int(ui), _, loc) = sub_expr {
-                Ok(TypeCheckedExpr::Const(
+            if let TypeCheckedExprKind::Const(Value::Int(ui), _) = sub_expr.kind {
+                Ok(TypeCheckedExprKind::Const(
                     Value::Int(ui.avm_hash()),
                     Type::Bytes32,
-                    loc,
                 ))
             } else {
-                Ok(TypeCheckedExpr::UnaryOp(
+                Ok(TypeCheckedExprKind::UnaryOp(
                     UnaryOp::Hash,
                     Box::new(sub_expr),
                     Type::Bytes32,
-                    loc,
                 ))
             }
         }
         UnaryOp::Len => match tc_type {
-            Type::Tuple(tv) => Ok(TypeCheckedExpr::Const(
+            Type::Tuple(tv) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_usize(tv.len())),
                 Type::Uint,
-                loc,
             )),
-            Type::FixedArray(_, sz) => Ok(TypeCheckedExpr::Const(
+            Type::FixedArray(_, sz) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_usize(sz)),
                 Type::Uint,
-                loc,
             )),
-            Type::Array(_) => Ok(TypeCheckedExpr::UnaryOp(
+            Type::Array(_) => Ok(TypeCheckedExprKind::UnaryOp(
                 UnaryOp::Len,
                 Box::new(sub_expr),
                 Type::Uint,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid operand type for len".to_string(),
@@ -2320,16 +2268,15 @@ fn typecheck_unary_op(
             )),
         },
         UnaryOp::ToUint => {
-            if let TypeCheckedExpr::Const(val, _, loc) = sub_expr {
-                Ok(TypeCheckedExpr::Const(val, Type::Uint, loc))
+            if let TypeCheckedExprKind::Const(val, _) = sub_expr.kind {
+                Ok(TypeCheckedExprKind::Const(val, Type::Uint))
             } else {
                 match tc_type {
                     Type::Uint | Type::Int | Type::Bytes32 | Type::EthAddress | Type::Bool => {
-                        Ok(TypeCheckedExpr::UnaryOp(
+                        Ok(TypeCheckedExprKind::UnaryOp(
                             UnaryOp::ToUint,
                             Box::new(sub_expr),
                             Type::Uint,
-                            loc,
                         ))
                     }
                     _ => Err(new_type_error(
@@ -2340,18 +2287,13 @@ fn typecheck_unary_op(
             }
         }
         UnaryOp::ToInt => {
-            if let TypeCheckedExpr::Const(val, _, loc) = sub_expr {
-                Ok(TypeCheckedExpr::Const(val, Type::Int, loc))
+            if let TypeCheckedExprKind::Const(val, _) = sub_expr.kind {
+                Ok(TypeCheckedExprKind::Const(val, Type::Int))
             } else {
                 match tc_type {
-                    Type::Uint | Type::Int | Type::Bytes32 | Type::EthAddress | Type::Bool => {
-                        Ok(TypeCheckedExpr::UnaryOp(
-                            UnaryOp::ToInt,
-                            Box::new(sub_expr),
-                            Type::Int,
-                            loc,
-                        ))
-                    }
+                    Type::Uint | Type::Int | Type::Bytes32 | Type::EthAddress | Type::Bool => Ok(
+                        TypeCheckedExprKind::UnaryOp(UnaryOp::ToInt, Box::new(sub_expr), Type::Int),
+                    ),
                     _ => Err(new_type_error(
                         "invalid operand type for int()".to_string(),
                         loc,
@@ -2360,16 +2302,15 @@ fn typecheck_unary_op(
             }
         }
         UnaryOp::ToBytes32 => {
-            if let TypeCheckedExpr::Const(val, _, loc) = sub_expr {
-                Ok(TypeCheckedExpr::Const(val, Type::Bytes32, loc))
+            if let TypeCheckedExprKind::Const(val, _) = sub_expr.kind {
+                Ok(TypeCheckedExprKind::Const(val, Type::Bytes32))
             } else {
                 match tc_type {
                     Type::Uint | Type::Int | Type::Bytes32 | Type::EthAddress | Type::Bool => {
-                        Ok(TypeCheckedExpr::UnaryOp(
+                        Ok(TypeCheckedExprKind::UnaryOp(
                             UnaryOp::ToBytes32,
                             Box::new(sub_expr),
                             Type::Bytes32,
-                            loc,
                         ))
                     }
                     _ => Err(new_type_error(
@@ -2380,16 +2321,15 @@ fn typecheck_unary_op(
             }
         }
         UnaryOp::ToAddress => {
-            if let TypeCheckedExpr::Const(val, _, loc) = sub_expr {
-                Ok(TypeCheckedExpr::Const(val, Type::EthAddress, loc))
+            if let TypeCheckedExprKind::Const(val, _) = sub_expr.kind {
+                Ok(TypeCheckedExprKind::Const(val, Type::EthAddress))
             } else {
                 match tc_type {
                     Type::Uint | Type::Int | Type::Bytes32 | Type::EthAddress | Type::Bool => {
-                        Ok(TypeCheckedExpr::UnaryOp(
+                        Ok(TypeCheckedExprKind::UnaryOp(
                             UnaryOp::ToAddress,
                             Box::new(sub_expr),
                             Type::EthAddress,
-                            loc,
                         ))
                     }
                     _ => Err(new_type_error(
@@ -2413,9 +2353,9 @@ fn typecheck_binary_op(
     mut tcs2: TypeCheckedExpr,
     type_tree: &TypeTree,
     loc: Option<Location>,
-) -> Result<TypeCheckedExpr, TypeError> {
-    if let TypeCheckedExpr::Const(Value::Int(val2), t2, _) = tcs2.clone() {
-        if let TypeCheckedExpr::Const(Value::Int(val1), t1, _) = tcs1.clone() {
+) -> Result<TypeCheckedExprKind, TypeError> {
+    if let TypeCheckedExprKind::Const(Value::Int(val2), t2) = tcs2.kind.clone() {
+        if let TypeCheckedExprKind::Const(Value::Int(val1), t1) = tcs1.kind.clone() {
             // both args are constants, so we can do the op at compile time
             return typecheck_binary_op_const(op, val1, t1, val2, t2, loc);
         } else {
@@ -2454,19 +2394,17 @@ fn typecheck_binary_op(
     let subtype2 = tcs2.get_type().get_representation(type_tree)?;
     match op {
         BinaryOp::Plus | BinaryOp::Minus | BinaryOp::Times => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Uint,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Int,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to binary op".to_string(),
@@ -2474,19 +2412,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::Div => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Uint,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::Sdiv,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Int,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to divide".to_string(),
@@ -2494,19 +2430,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::Mod => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Uint,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::Smod,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Int,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to mod".to_string(),
@@ -2514,19 +2448,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::LessThan => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::SLessThan,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to <".to_string(),
@@ -2534,19 +2466,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::GreaterThan => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::SGreaterThan,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to >".to_string(),
@@ -2554,19 +2484,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::LessEq => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::SLessEq,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to <=".to_string(),
@@ -2574,19 +2502,17 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::GreaterEq => match (subtype1, subtype2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                 BinaryOp::SGreaterEq,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to >=".to_string(),
@@ -2595,12 +2521,11 @@ fn typecheck_binary_op(
         },
         BinaryOp::Equal | BinaryOp::NotEqual => {
             if (subtype1 == Type::Any) || (subtype2 == Type::Any) || (subtype1 == subtype2) {
-                Ok(TypeCheckedExpr::Binary(
+                Ok(TypeCheckedExprKind::Binary(
                     op,
                     Box::new(tcs1),
                     Box::new(tcs2),
                     Type::Bool,
-                    loc,
                 ))
             } else {
                 Err(new_type_error(
@@ -2614,26 +2539,23 @@ fn typecheck_binary_op(
         }
         BinaryOp::BitwiseAnd | BinaryOp::BitwiseOr | BinaryOp::BitwiseXor => {
             match (subtype1, subtype2) {
-                (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Binary(
+                (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Binary(
                     op,
                     Box::new(tcs1),
                     Box::new(tcs2),
                     Type::Uint,
-                    loc,
                 )),
-                (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Binary(
+                (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Binary(
                     op,
                     Box::new(tcs1),
                     Box::new(tcs2),
                     Type::Int,
-                    loc,
                 )),
-                (Type::Bytes32, Type::Bytes32) => Ok(TypeCheckedExpr::Binary(
+                (Type::Bytes32, Type::Bytes32) => Ok(TypeCheckedExprKind::Binary(
                     op,
                     Box::new(tcs1),
                     Box::new(tcs2),
                     Type::Bytes32,
-                    loc,
                 )),
                 _ => Err(new_type_error(
                     "invalid argument types to binary bitwise operator".to_string(),
@@ -2642,12 +2564,11 @@ fn typecheck_binary_op(
             }
         }
         BinaryOp::_LogicalAnd | BinaryOp::LogicalOr => match (subtype1, subtype2) {
-            (Type::Bool, Type::Bool) => Ok(TypeCheckedExpr::Binary(
+            (Type::Bool, Type::Bool) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to binary logical operator".to_string(),
@@ -2655,12 +2576,11 @@ fn typecheck_binary_op(
             )),
         },
         BinaryOp::Hash => match (subtype1, subtype2) {
-            (Type::Bytes32, Type::Bytes32) => Ok(TypeCheckedExpr::Binary(
+            (Type::Bytes32, Type::Bytes32) => Ok(TypeCheckedExprKind::Binary(
                 op,
                 Box::new(tcs1),
                 Box::new(tcs2),
                 Type::Bytes32,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to binary hash operator".to_string(),
@@ -2693,10 +2613,10 @@ fn typecheck_binary_op_const(
     val2: Uint256,
     t2: Type,
     loc: Option<Location>,
-) -> Result<TypeCheckedExpr, TypeError> {
+) -> Result<TypeCheckedExprKind, TypeError> {
     match op {
         BinaryOp::Plus | BinaryOp::Minus | BinaryOp::Times => match (&t1, &t2) {
-            (Type::Uint, Type::Uint) | (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Const(
+            (Type::Uint, Type::Uint) | (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(match op {
                     BinaryOp::Plus => val1.add(&val2),
                     BinaryOp::Minus => {
@@ -2715,7 +2635,6 @@ fn typecheck_binary_op_const(
                     }
                 }),
                 t1,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to binary op".to_string(),
@@ -2724,11 +2643,11 @@ fn typecheck_binary_op_const(
         },
         BinaryOp::Div => match (&t1, &t2) {
             (Type::Uint, Type::Uint) => match val1.div(&val2) {
-                Some(v) => Ok(TypeCheckedExpr::Const(Value::Int(v), t1, loc)),
+                Some(v) => Ok(TypeCheckedExprKind::Const(Value::Int(v), t1)),
                 None => Err(new_type_error("divide by constant zero".to_string(), loc)),
             },
             (Type::Int, Type::Int) => match val1.sdiv(&val2) {
-                Some(v) => Ok(TypeCheckedExpr::Const(Value::Int(v), t1, loc)),
+                Some(v) => Ok(TypeCheckedExprKind::Const(Value::Int(v), t1)),
                 None => Err(new_type_error("divide by constant zero".to_string(), loc)),
             },
             _ => Err(new_type_error(
@@ -2738,11 +2657,11 @@ fn typecheck_binary_op_const(
         },
         BinaryOp::Mod => match (&t1, &t2) {
             (Type::Uint, Type::Uint) => match val1.modulo(&val2) {
-                Some(v) => Ok(TypeCheckedExpr::Const(Value::Int(v), t1, loc)),
+                Some(v) => Ok(TypeCheckedExprKind::Const(Value::Int(v), t1)),
                 None => Err(new_type_error("divide by constant zero".to_string(), loc)),
             },
             (Type::Int, Type::Int) => match val1.smodulo(&val2) {
-                Some(v) => Ok(TypeCheckedExpr::Const(Value::Int(v), t1, loc)),
+                Some(v) => Ok(TypeCheckedExprKind::Const(Value::Int(v), t1)),
                 None => Err(new_type_error("divide by constant zero".to_string(), loc)),
             },
             _ => Err(new_type_error(
@@ -2751,15 +2670,13 @@ fn typecheck_binary_op_const(
             )),
         },
         BinaryOp::LessThan => match (t1, t2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Const(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val1 < val2)),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Const(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val1.s_less_than(&val2))),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to <".to_string(),
@@ -2767,15 +2684,13 @@ fn typecheck_binary_op_const(
             )),
         },
         BinaryOp::GreaterThan => match (t1, t2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Const(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val1 > val2)),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Const(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val2.s_less_than(&val1))),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to >".to_string(),
@@ -2783,15 +2698,13 @@ fn typecheck_binary_op_const(
             )),
         },
         BinaryOp::LessEq => match (t1, t2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Const(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val1 <= val2)),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Const(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(!val2.s_less_than(&val1))),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to <=".to_string(),
@@ -2799,15 +2712,13 @@ fn typecheck_binary_op_const(
             )),
         },
         BinaryOp::GreaterEq => match (t1, t2) {
-            (Type::Uint, Type::Uint) => Ok(TypeCheckedExpr::Const(
+            (Type::Uint, Type::Uint) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(val1 >= val2)),
                 Type::Bool,
-                loc,
             )),
-            (Type::Int, Type::Int) => Ok(TypeCheckedExpr::Const(
+            (Type::Int, Type::Int) => Ok(TypeCheckedExprKind::Const(
                 Value::Int(Uint256::from_bool(!val1.s_less_than(&val2))),
                 Type::Bool,
-                loc,
             )),
             _ => Err(new_type_error(
                 "invalid argument types to >=".to_string(),
@@ -2821,7 +2732,7 @@ fn typecheck_binary_op_const(
         | BinaryOp::BitwiseXor
         | BinaryOp::Hash => {
             if t1 == t2 {
-                Ok(TypeCheckedExpr::Const(
+                Ok(TypeCheckedExprKind::Const(
                     Value::Int(match op {
                         BinaryOp::Equal => Uint256::from_bool(val1 == val2),
                         BinaryOp::NotEqual => Uint256::from_bool(val1 != val2),
@@ -2830,10 +2741,9 @@ fn typecheck_binary_op_const(
                         BinaryOp::BitwiseXor => val1.bitwise_xor(&val2),
                         BinaryOp::Hash => {
                             if let Type::Bytes32 = t1 {
-                                return Ok(TypeCheckedExpr::Const(
+                                return Ok(TypeCheckedExprKind::Const(
                                     Value::avm_hash2(&Value::Int(val1), &Value::Int(val2)),
                                     Type::Bool,
-                                    loc,
                                 ));
                             } else {
                                 return Err(new_type_error(
@@ -2847,7 +2757,6 @@ fn typecheck_binary_op_const(
                         }
                     }),
                     Type::Bool,
-                    loc,
                 ))
             } else {
                 Err(new_type_error(
@@ -2858,10 +2767,9 @@ fn typecheck_binary_op_const(
         }
         BinaryOp::_LogicalAnd => {
             if (t1 == Type::Bool) && (t2 == Type::Bool) {
-                Ok(TypeCheckedExpr::Const(
+                Ok(TypeCheckedExprKind::Const(
                     Value::Int(Uint256::from_bool(!val1.is_zero() && !val2.is_zero())),
                     Type::Bool,
-                    loc,
                 ))
             } else {
                 Err(new_type_error(
@@ -2872,10 +2780,9 @@ fn typecheck_binary_op_const(
         }
         BinaryOp::LogicalOr => {
             if (t1 == Type::Bool) && (t2 == Type::Bool) {
-                Ok(TypeCheckedExpr::Const(
+                Ok(TypeCheckedExprKind::Const(
                     Value::Int(Uint256::from_bool(!val1.is_zero() || !val2.is_zero())),
                     Type::Bool,
-                    loc,
                 ))
             } else {
                 Err(new_type_error(

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -3,7 +3,7 @@
 //
 
 use crate::compile::ast::{TopLevelDecl, TypeDecl, FuncDecl, GlobalVarDecl, ImportFuncDecl, ImportTypeDecl, Type,
-StructField, FuncArg, Statement, StatementKind, DebugInfo, MatchPattern, IfArm, Expr, BinaryOp, UnaryOp, Constant,
+StructField, FuncArg, Statement, StatementKind, DebugInfo, MatchPattern, IfArm, Expr, ExprKind, BinaryOp, UnaryOp, Constant,
 OptionConst, FieldInitializer, new_func_arg, new_type_decl};
 use crate::stringtable::{StringTable, StringId};
 use crate::compile::Lines;
@@ -88,7 +88,7 @@ StatementKind: StatementKind = {
 	<i: Ident> "=" <e: Expr> ";" => StatementKind::Assign(i, e),
 	"return" <e: Expr> ";" => StatementKind::Return(e),
 	"return" ";" => StatementKind::ReturnVoid(),
-	<lno: @L> "return" "None" ";" => StatementKind::Return(Expr::Constant(Constant::Option(OptionConst::None(Type::Every)),file_info.location(BytePos::from(lno),filename))),
+	<lno: @L> "return" "None" ";" => StatementKind::Return(Expr{ kind: ExprKind::Constant(Constant::Option(OptionConst::None(Type::Every))), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)} }),
 	"break" <e: Expr?> ";" => StatementKind::Break(e,None),
 	"panic" ";" => StatementKind::Panic(),
 	"debug" "(" <e: Expr> ")" ";" => StatementKind::DebugPrint(e),
@@ -155,23 +155,24 @@ Ident: StringId = {
 };
 
 Expr: Expr = {
-	<lno: @L> <t:Expr> "with" "{" "[" <i:Expr> "]" "=" <v:Expr> "}" => Expr::ArrayOrMapMod(
+	<lno: @L> <t:Expr> "with" "{" "[" <i:Expr> "]" "=" <v:Expr> "}" => Expr { kind: ExprKind::ArrayOrMapMod(
 		Box::new(t), 
 		Box::new(i), 
-		Box::new(v),
-		file_info.location(BytePos::from(lno),filename),
-	),
-	<lno: @L> <t: Expr> "with" "{" <i:Ident> ":" <e: Expr> "}" => Expr::StructMod(Box::new(t), stringtable.name_from_id(i).to_string(), Box::new(e), file_info.location(BytePos::from(lno),filename)),
+		Box::new(v),),
+		debug_info: DebugInfo {
+		    location: file_info.location(BytePos::from(lno),filename),
+	}},
+	<lno: @L> <t: Expr> "with" "{" <i:Ident> ":" <e: Expr> "}" => Expr { kind: ExprKind::StructMod(Box::new(t), stringtable.name_from_id(i).to_string(), Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr1,
 }
 
 Expr1: Expr = {
-	<lno: @L> <l:Expr1> "||" <r:Expr2> => Expr::ShortcutOr(Box::new(l), Box::new(r), file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> <l:Expr1> "||" <r:Expr2> => Expr { kind: ExprKind::ShortcutOr(Box::new(l), Box::new(r)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr2,
 };
 
 Expr2: Expr = {
-	<lno: @L> <l:Expr2> "&&" <r:Expr3> => Expr::ShortcutAnd(Box::new(l), Box::new(r), file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> <l:Expr2> "&&" <r:Expr3> => Expr { kind: ExprKind::ShortcutAnd(Box::new(l), Box::new(r)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr3,
 };
 
@@ -218,7 +219,7 @@ Expr8: Expr = {
 };
 
 Expr9: Expr = {
-	<lno: @L> <e: Expr9> "?" => Expr::Try(Box::new(e), file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> <e: Expr9> "?" => Expr { kind: ExprKind::Try(Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr10,
 }
 
@@ -230,13 +231,13 @@ Expr10: Expr = {
 };
 
 Expr11: Expr = {
-	<lno: @L> <c: Const> => Expr::Constant(c, file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "Some(" <e: Expr> ")" => Expr::OptionInitializer(Box::new(e), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <f: Expr11> "(" <e: Expr> ")" => Expr::FunctionCall(Box::new(f), vec![e], file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <f: Expr11> "(" <c: CommaedExprs?> ")" => Expr::FunctionCall(Box::new(f), c.unwrap_or(vec![]), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <e1:Expr11> "[" <e2:Expr> "]" => Expr::ArrayOrMapRef(Box::new(e1), Box::new(e2), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <e:Expr11> "." <i:Ident> => Expr::DotRef(Box::new(e), stringtable.name_from_id(i).to_string(), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr::TupleRef(Box::new(e), u, file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> <c: Const> => Expr { kind: ExprKind::Constant(c), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "Some(" <e: Expr> ")" => Expr { kind: ExprKind::OptionInitializer(Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <f: Expr11> "(" <e: Expr> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), vec![e]), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <f: Expr11> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), c.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <e1:Expr11> "[" <e2:Expr> "]" => Expr { kind: ExprKind::ArrayOrMapRef(Box::new(e1), Box::new(e2)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <e:Expr11> "." <i:Ident> => Expr { kind: ExprKind::DotRef(Box::new(e), stringtable.name_from_id(i).to_string()), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr { kind: ExprKind::TupleRef(Box::new(e), u), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr12,
 }
 
@@ -248,29 +249,29 @@ Expr12: Expr = {
 	<lno: @L> "int" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToInt, e, file_info.location(BytePos::from(lno),filename)),
 	<lno: @L> "bytes32" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToBytes32, e, file_info.location(BytePos::from(lno),filename)),
 	<lno: @L> "address" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToAddress, e, file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "newarray" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr::NewArray(Box::new(e), t, file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> "," <e:Expr> ","? ")" => Expr::NewFixedArray(
+	<lno: @L> "newarray" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::NewArray(Box::new(e), t), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> "," <e:Expr> ","? ")" => Expr { kind: ExprKind::NewFixedArray(
 		s.to_usize().unwrap(),
-		Some(Box::new(e)),
-		file_info.location(BytePos::from(lno),filename),
-	),
-	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> ")" => Expr::NewFixedArray(
+		Some(Box::new(e))),
+		debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)
+	}},
+	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> ")" => Expr { kind: ExprKind::NewFixedArray(
 		s.to_usize().unwrap(),
-		None,
-		file_info.location(BytePos::from(lno),filename),
-	),
-	<lno: @L> "newmap" "<" <k:Type> "," <v:Type> ","? ">" => Expr::NewMap(k, v, file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "unsafecast" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr::UnsafeCast(Box::new(e), t, file_info.location(BytePos::from(lno),filename)),
+		None),
+		debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename),
+	}},
+	<lno: @L> "newmap" "<" <k:Type> "," <v:Type> ","? ">" => Expr { kind: ExprKind::NewMap(k, v), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "unsafecast" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::UnsafeCast(Box::new(e), t), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	Expr13,
 }
 
 Expr13: Expr = {
-	<lno: @L> "asm" "(" <a:CommaedExprs?> ")" <rt:Type> "{" <body:AsmInsn*> "}" => Expr::Asm(rt, body, a.unwrap_or(vec![]), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "struct" "{" <fi: FieldInitializers> "}" => Expr::StructInitializer(fi, file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> "asm" "(" <a:CommaedExprs?> ")" <rt:Type> "{" <body:AsmInsn*> "}" => Expr { kind: ExprKind::Asm(rt, body, a.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "struct" "{" <fi: FieldInitializers> "}" => Expr { kind: ExprKind::StructInitializer(fi), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 	"(" <e: Expr> ")" => <>,
-	<lno: @L> "{" <cb: Statement*> <e: Expr?> "}" => Expr::CodeBlock(cb, e.map(|x| Box::new(x)), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "(" <c: CommaedExprs?> ")" => Expr::Tuple(c.unwrap_or(vec![]), file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> <i: Ident> => Expr::VariableRef(i, file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> "{" <cb: Statement*> <e: Expr?> "}" => Expr { kind: ExprKind::CodeBlock(cb, e.map(|x| Box::new(x))), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::Tuple(c.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <i: Ident> => Expr { kind: ExprKind::VariableRef(i), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
 }
 
 Const: Constant = {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -82,7 +82,7 @@ StatementKind: StatementKind = {
 	"while" "(" <e: Expr> ")" <cb: CodeBlock> => StatementKind::While(e, cb),
 	"loop" <cb: CodeBlock> => StatementKind::Loop(cb),
 	"if" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlock> <e: ("else" <CodeBlock>)?> => StatementKind::IfLet(l,r,t,e),
-	<lno: @L> "if" "(" <c: Expr> ")" <t: CodeBlock> <r: IfArm?> => StatementKind::If(IfArm::Cond(c, t, r.map(|m|Box::new(m)), file_info.location(BytePos::from(lno),filename))),
+	<lno: @L> "if" "(" <c: Expr> ")" <t: CodeBlock> <r: IfArm?> => StatementKind::If(IfArm::Cond(c, t, r.map(|m|Box::new(m)), DebugInfo::from(file_info.location(BytePos::from(lno),filename)))),
 	"let" <p: MatchPattern> "=" <e: Expr> ";" => StatementKind::Let(p, e),
 	<e: Expr> ";" => StatementKind::Expression(e),
 	<i: Ident> "=" <e: Expr> ";" => StatementKind::Assign(i, e),
@@ -106,8 +106,8 @@ CommaedMatchPatterns: Vec<MatchPattern> = {
 }
 
 IfArm: IfArm = {
-	<lno: @L> "else" <cb: CodeBlock> => IfArm::Catchall(cb, file_info.location(BytePos::from(lno), filename)),
-	<lno: @L> "elseif" "(" <c: Expr> ")" <cb: CodeBlock> <r: IfArm?> => IfArm::Cond(c, cb, r.map(|m| Box::new(m)), file_info.location(BytePos::from(lno),filename)),
+	<lno: @L> "else" <cb: CodeBlock> => IfArm::Catchall(cb, DebugInfo::from(file_info.location(BytePos::from(lno), filename))),
+	<lno: @L> "elseif" "(" <c: Expr> ")" <cb: CodeBlock> <r: IfArm?> => IfArm::Cond(c, cb, r.map(|m| Box::new(m)), DebugInfo::from(file_info.location(BytePos::from(lno),filename))),
 }
 
 StructFields: Vec<StructField> = {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -75,7 +75,7 @@ CodeBlock: Vec<Statement> = {
 }
 
 Statement: Statement = {
-	<lno: @L> <kind:StatementKind> => Statement {kind, debug_info: DebugInfo { location: file_info.location(BytePos::from(lno), filename)}},
+	<lno: @L> <kind:StatementKind> => Statement {kind, debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 }
 
 StatementKind: StatementKind = {
@@ -88,7 +88,7 @@ StatementKind: StatementKind = {
 	<i: Ident> "=" <e: Expr> ";" => StatementKind::Assign(i, e),
 	"return" <e: Expr> ";" => StatementKind::Return(e),
 	"return" ";" => StatementKind::ReturnVoid(),
-	<lno: @L> "return" "None" ";" => StatementKind::Return(Expr{ kind: ExprKind::Constant(Constant::Option(OptionConst::None(Type::Every))), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)} }),
+	<lno: @L> "return" "None" ";" => StatementKind::Return(Expr{ kind: ExprKind::Constant(Constant::Option(OptionConst::None(Type::Every))), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))}),
 	"break" <e: Expr?> ";" => StatementKind::Break(e,None),
 	"panic" ";" => StatementKind::Panic(),
 	"debug" "(" <e: Expr> ")" ";" => StatementKind::DebugPrint(e),
@@ -159,20 +159,18 @@ Expr: Expr = {
 		Box::new(t), 
 		Box::new(i), 
 		Box::new(v),),
-		debug_info: DebugInfo {
-		    location: file_info.location(BytePos::from(lno),filename),
-	}},
-	<lno: @L> <t: Expr> "with" "{" <i:Ident> ":" <e: Expr> "}" => Expr { kind: ExprKind::StructMod(Box::new(t), stringtable.name_from_id(i).to_string(), Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+		debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <t: Expr> "with" "{" <i:Ident> ":" <e: Expr> "}" => Expr { kind: ExprKind::StructMod(Box::new(t), stringtable.name_from_id(i).to_string(), Box::new(e)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr1,
 }
 
 Expr1: Expr = {
-	<lno: @L> <l:Expr1> "||" <r:Expr2> => Expr { kind: ExprKind::ShortcutOr(Box::new(l), Box::new(r)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <l:Expr1> "||" <r:Expr2> => Expr { kind: ExprKind::ShortcutOr(Box::new(l), Box::new(r)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr2,
 };
 
 Expr2: Expr = {
-	<lno: @L> <l:Expr2> "&&" <r:Expr3> => Expr { kind: ExprKind::ShortcutAnd(Box::new(l), Box::new(r)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <l:Expr2> "&&" <r:Expr3> => Expr { kind: ExprKind::ShortcutAnd(Box::new(l), Box::new(r)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr3,
 };
 
@@ -219,7 +217,7 @@ Expr8: Expr = {
 };
 
 Expr9: Expr = {
-	<lno: @L> <e: Expr9> "?" => Expr { kind: ExprKind::Try(Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <e: Expr9> "?" => Expr { kind: ExprKind::Try(Box::new(e)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr10,
 }
 
@@ -231,13 +229,13 @@ Expr10: Expr = {
 };
 
 Expr11: Expr = {
-	<lno: @L> <c: Const> => Expr { kind: ExprKind::Constant(c), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> "Some(" <e: Expr> ")" => Expr { kind: ExprKind::OptionInitializer(Box::new(e)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <f: Expr11> "(" <e: Expr> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), vec![e]), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <f: Expr11> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), c.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <e1:Expr11> "[" <e2:Expr> "]" => Expr { kind: ExprKind::ArrayOrMapRef(Box::new(e1), Box::new(e2)), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <e:Expr11> "." <i:Ident> => Expr { kind: ExprKind::DotRef(Box::new(e), stringtable.name_from_id(i).to_string()), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr { kind: ExprKind::TupleRef(Box::new(e), u), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> <c: Const> => Expr { kind: ExprKind::Constant(c), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> "Some(" <e: Expr> ")" => Expr { kind: ExprKind::OptionInitializer(Box::new(e)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <f: Expr11> "(" <e: Expr> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), vec![e]), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <f: Expr11> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::FunctionCall(Box::new(f), c.unwrap_or(vec![])), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <e1:Expr11> "[" <e2:Expr> "]" => Expr { kind: ExprKind::ArrayOrMapRef(Box::new(e1), Box::new(e2)), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <e:Expr11> "." <i:Ident> => Expr { kind: ExprKind::DotRef(Box::new(e), stringtable.name_from_id(i).to_string()), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr { kind: ExprKind::TupleRef(Box::new(e), u), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr12,
 }
 
@@ -249,29 +247,29 @@ Expr12: Expr = {
 	<lno: @L> "int" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToInt, e, file_info.location(BytePos::from(lno),filename)),
 	<lno: @L> "bytes32" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToBytes32, e, file_info.location(BytePos::from(lno),filename)),
 	<lno: @L> "address" "(" <e: Expr> ")" => Expr::new_unary(UnaryOp::ToAddress, e, file_info.location(BytePos::from(lno),filename)),
-	<lno: @L> "newarray" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::NewArray(Box::new(e), t), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "newarray" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::NewArray(Box::new(e), t), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> "," <e:Expr> ","? ")" => Expr { kind: ExprKind::NewFixedArray(
 		s.to_usize().unwrap(),
 		Some(Box::new(e))),
-		debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)
-	}},
+		debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))
+	},
 	<lno: @L> "newfixedarray" "(" <s:UnsignedInteger> ")" => Expr { kind: ExprKind::NewFixedArray(
 		s.to_usize().unwrap(),
 		None),
-		debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename),
-	}},
-	<lno: @L> "newmap" "<" <k:Type> "," <v:Type> ","? ">" => Expr { kind: ExprKind::NewMap(k, v), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> "unsafecast" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::UnsafeCast(Box::new(e), t), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+		debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename)),
+	},
+	<lno: @L> "newmap" "<" <k:Type> "," <v:Type> ","? ">" => Expr { kind: ExprKind::NewMap(k, v), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> "unsafecast" "<" <t:Type> ">" "(" <e:Expr> ")" => Expr { kind: ExprKind::UnsafeCast(Box::new(e), t), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr13,
 }
 
 Expr13: Expr = {
-	<lno: @L> "asm" "(" <a:CommaedExprs?> ")" <rt:Type> "{" <body:AsmInsn*> "}" => Expr { kind: ExprKind::Asm(rt, body, a.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> "struct" "{" <fi: FieldInitializers> "}" => Expr { kind: ExprKind::StructInitializer(fi), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "asm" "(" <a:CommaedExprs?> ")" <rt:Type> "{" <body:AsmInsn*> "}" => Expr { kind: ExprKind::Asm(rt, body, a.unwrap_or(vec![])), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> "struct" "{" <fi: FieldInitializers> "}" => Expr { kind: ExprKind::StructInitializer(fi), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	"(" <e: Expr> ")" => <>,
-	<lno: @L> "{" <cb: Statement*> <e: Expr?> "}" => Expr { kind: ExprKind::CodeBlock(cb, e.map(|x| Box::new(x))), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::Tuple(c.unwrap_or(vec![])), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
-	<lno: @L> <i: Ident> => Expr { kind: ExprKind::VariableRef(i), debug_info: DebugInfo { location: file_info.location(BytePos::from(lno),filename)}},
+	<lno: @L> "{" <cb: Statement*> <e: Expr?> "}" => Expr { kind: ExprKind::CodeBlock(cb, e.map(|x| Box::new(x))), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> "(" <c: CommaedExprs?> ")" => Expr { kind: ExprKind::Tuple(c.unwrap_or(vec![])), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> <i: Ident> => Expr { kind: ExprKind::VariableRef(i), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 }
 
 Const: Constant = {


### PR DESCRIPTION
This PR refactors the way that the data in the AST is structured, splitting each node into a main struct containing DebugInfo, and a kind enum without debug information.