### PR TITLE
Bytearray size limit

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -135,7 +135,7 @@ public impure func arbsys_txcall() {
         }
     } else {
         // this shouldn't happen -- should always be called in an EVM tx
-        evmCallStack_callHitError(14);
+        evmCallStack_callHitError(21);
     }
 }
 

--- a/arb_os/chainParameters.mini
+++ b/arb_os/chainParameters.mini
@@ -8,7 +8,6 @@ use evmCallStack::evmCallStack_callHitError;
 use std::bytearray::MarshalledBytes;
 use std::bytearray::ByteArray;
 use std::bytearray::MarshalledBytes;
-use std::bytearray::bytearray_unmarshalBytes;
 use std::bytearray::bytearray_get256;
 
 use std::bytestream::ByteStream;
@@ -91,7 +90,7 @@ public impure func chainParams_chainAddress() -> address {
         return params.chainAddress;
     } else {
         // If we get here, the chain never received its initialization message.
-        evmCallStack_callHitError(15);
+        evmCallStack_callHitError(20);
         panic;
     }
 }

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -17,7 +17,6 @@ use accounts::account_addToEthBalance;
 use accounts::account_deductFromEthBalance;
 
 use std::bytearray::bytearray_new;
-use std::bytearray::bytearray_unmarshalBytes;
 use std::bytearray::bytearray_getByte;
 use std::bytearray::bytearray_get256;
 

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -134,36 +134,41 @@ impure func getFromL1Inbox(inbox: Inbox) -> Inbox {
         }
     }
     let newMsgRaw = asm() IncomingRequestFromInbox { inbox };
-    let newMsg = struct {
-        kind: newMsgRaw.kind,
-        blockNumber: newMsgRaw.blockNumber,
-        timestamp: newMsgRaw.timestamp,
-        sender: newMsgRaw.sender,
-        requestId: newMsgRaw.requestId,
-        msgData: bytearray_unmarshalBytes(newMsgRaw.msgData),
-        provenance: struct {
-            l1SeqNum: newMsgRaw.requestId,
-            parentRequestId: 0,
-            indexInParent: ~0,
-        },
-    };
+    if let Some(msgData) = bytearray_unmarshalBytes(newMsgRaw.msgData) {
+        let newMsg = struct {
+            kind: newMsgRaw.kind,
+            blockNumber: newMsgRaw.blockNumber,
+            timestamp: newMsgRaw.timestamp,
+            sender: newMsgRaw.sender,
+            requestId: newMsgRaw.requestId,
+            msgData: msgData,
+            provenance: struct {
+                l1SeqNum: newMsgRaw.requestId,
+                parentRequestId: 0,
+                indexInParent: ~0,
+            },
+        };
 
-    if (newMsg.blockNumber == 0) {
-        newMsg = newMsg with { blockNumber: inbox.blockNum };
-    }
-    if (newMsg.timestamp == 0) {
-        newMsg = newMsg with { timestamp: inbox.timestamp };
-    }
+        if (newMsg.blockNumber == 0) {
+            newMsg = newMsg with { blockNumber: inbox.blockNum };
+        }
+        if (newMsg.timestamp == 0) {
+            newMsg = newMsg with { timestamp: inbox.timestamp };
+        }
 
-    return inbox with {
-        queue: queue_put(inbox.queue, newMsg)
-    } with {
-        needToPeek: true
-    } with {
-        blockNum: newMsg.blockNumber
-    } with {
-        timestamp: newMsg.timestamp
-    };
+        return inbox with {
+            queue: queue_put(inbox.queue, newMsg)
+        } with {
+            needToPeek: true
+        } with {
+            blockNum: newMsg.blockNumber
+        } with {
+            timestamp: newMsg.timestamp
+        };
+    } else {
+        // message was malformatted; ignore it and return; caller will call this function again
+        return inbox;
+    }
 }
 
 public impure func inbox_currentTimestamp() -> uint {

--- a/arb_os/main.mini
+++ b/arb_os/main.mini
@@ -105,7 +105,7 @@ public impure func mainRunLoop() {
 impure func initializeContractTemplates() -> option<()> {
     let acctStore = getGlobalAccountStore();
 
-    let code = bytearray_unmarshalBytes(getErc20code());
+    let code = bytearray_unmarshalBytes(getErc20code())?;
     let (initCodePt, evmJumpTable, _) = translateEvmCodeSegment(
         bytestream_new(code),
         false
@@ -119,7 +119,7 @@ impure func initializeContractTemplates() -> option<()> {
         getErc20storage()
     )?;
 
-    let code = bytearray_unmarshalBytes(getErc721code());
+    let code = bytearray_unmarshalBytes(getErc721code())?;
     let (initCodePt, evmJumpTable, _) = translateEvmCodeSegment(
         bytestream_new(code),
         false
@@ -133,7 +133,7 @@ impure func initializeContractTemplates() -> option<()> {
         getErc721storage()
     )?;
 
-    let code = bytearray_unmarshalBytes(getArbInfoCode());
+    let code = bytearray_unmarshalBytes(getArbInfoCode())?;
     let (initCodePt, evmJumpTable, _) = translateEvmCodeSegment(
         bytestream_new(code),
         false

--- a/arb_os/messageBatch.mini
+++ b/arb_os/messageBatch.mini
@@ -10,7 +10,6 @@ use std::bytearray::bytearray_size;
 use std::bytearray::bytearray_getByte;
 use std::bytearray::bytearray_get256;
 use std::bytearray::bytearray_setByte;
-use std::bytearray::bytearray_unmarshalBytes;
 use std::bytearray::bytearray_marshalFull;
 use std::bytearray::bytearray_extract;
 use std::bytestream::bytestream_new;

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -33,7 +33,6 @@ use tokens::tokens_erc721deposit;
 
 use std::bytearray::bytearray_new;
 use std::bytearray::bytearray_size;
-use std::bytearray::bytearray_unmarshalBytes;
 use std::bytearray::bytearray_marshalFull;
 use std::bytearray::bytearray_extract;
 

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -13,7 +13,6 @@ use std::bytearray::bytearray_get256;
 use std::bytearray::bytearray_setByte;
 use std::bytearray::bytearray_set256;
 use std::bytearray::bytearray_extract;
-use std::bytearray::bytearray_unmarshalBytes;
 use std::bytearray::bytearray_marshalFull;
 use std::bytearray::marshalledBytes_hash;
 use std::bytearray::bytearray_copy;

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -27,7 +27,7 @@ type ByteArray = struct {
 // bytearray_new makes a new ByteArray
 // it will initially have size zero,
 //        reads beyond the end will return zero,
-//        size will expand to fit all writes,
+//        size will expand to fit all writes (but max size is 2**64 bytes),
 //        and the capacity arg is a hint about how big it will get
 public func bytearray_new(ignored: uint) -> ByteArray {
     return struct {
@@ -75,9 +75,12 @@ public func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32 {
 }
 
 // bytearray_unmarshalBytes unmarshals a bytestack object that we got from L1
-//        returns a new bytearray holding the unmarshaled bytes
-public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> ByteArray {
+//        returns a new bytearray holding the unmarshaled bytes, or None if unmarshalled array would be too large
+public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> option<ByteArray> {
     let nbytes = inBytes.nbytes;
+    if (nbytes > 0x100000000000000000000000000000000) {
+        return None;
+    }
     let nwords = (nbytes+31)/32;
     let words = inBytes.contents;
 
@@ -96,11 +99,11 @@ public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> ByteArray {
         words = unsafecast<MarshalledBytesCell>(words.rest);
     }
 
-    return struct {
+    return Some(struct {
         size: inBytes.nbytes,
         sliceOffset: 0,
         contents: eia,
-    };
+    });
 }
 
 public func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes {
@@ -200,6 +203,9 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
 // bytearray_setbyte writes one byte to a ByteArray, returns the resulting ByteArray
 public func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArray {
     if (offset >= ba.size) {
+        if (offset >= 0x100000000000000000000000000000000) {
+            return ba;    // ignore out-of-bounds write
+        }
         ba = ba with { size: offset+1 };
     }
     offset = offset + ba.sliceOffset;
@@ -216,6 +222,9 @@ public func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArr
 
 // bytearray_set64 writes an 8-byte chunk to a ByteArray, returning the resulting ByteArray
 public func bytearray_set64(ba: ByteArray, offset: uint, value: uint) -> ByteArray {
+    if (offset >= 0x100000000000000000000000000000000-7) {
+        return ba;    // ignore out-of-bounds write
+    }
     if (offset+8 > ba.size) {
         ba = ba with { size: offset+8 };
     }
@@ -251,6 +260,9 @@ public func bytearray_set64(ba: ByteArray, offset: uint, value: uint) -> ByteArr
 
 // bytearray_set256 writes a 32-byte chunk to a ByteArray, returning the resulting ByteArray
 public func bytearray_set256(ba: ByteArray, offset: uint, value: uint) -> ByteArray {
+    if (offset >= 0x100000000000000000000000000000000-31) {
+        return ba;    // ignore out-of-bounds write
+    }
     if (offset+32 > ba.size) {
         ba = ba with { size: offset+32 };
     }
@@ -287,6 +299,12 @@ public func bytearray_copy(
     toOffset: uint,
     nbytes: uint,
 ) -> ByteArray {
+    if ((fromOffset >= 0x100000000000000000000000000000000)
+        || (toOffset >= 0x100000000000000000000000000000000)
+        || (nbytes >= 0x100000000000000000000000000000000) ) {
+        return to;  // ignore out-of-bounds parameters
+    }
+
     // TODO: optimize this to exploit alignment and speed up the endgame
     while (nbytes >= 32) {
         let val = bytearray_get256(from, fromOffset);
@@ -306,6 +324,12 @@ public func bytearray_copy(
 }
 
 public func bytearray_extract(from: ByteArray, offset: uint, nbytes: uint) -> ByteArray {
+    if (offset >= 0x100000000000000000000000000000000) {
+        return bytearray_new(0);
+    }
+    if ((nbytes >= 0x100000000000000000000000000000000) || (offset+nbytes >= 0x100000000000000000000000000000000)) {
+        nbytes = 0x100000000000000000000000000000000 - offset;
+    }
     return from with {
         size: nbytes
     } with {

--- a/stdlib/bytearraytest.mini
+++ b/stdlib/bytearraytest.mini
@@ -89,15 +89,18 @@ func tests() -> uint {
 	));
 
 	ba = bytearray_new(67);
-	ba = bytearray_unmarshalBytes(marshalledStruct);
-	let i = 0;
-	while (i < 67) {
-		let b = bytearray_getByte(ba, i);
-		if (b != i) {
-			return 100+i;
-		}
-		i = i+1;
-	}
+	if let Some(ba2) = bytearray_unmarshalBytes(marshalledStruct) {
+        let i = 0;
+        while (i < 67) {
+            let b = bytearray_getByte(ba2, i);
+            if (b != i) {
+                return 100+i;
+            }
+            i = i+1;
+        }
+    } else {
+        return 8;
+    }
 
 	ba = setupFromUnmarshal();
 	let res = bytearray_get64(ba, 3);
@@ -183,5 +186,9 @@ func setupFromUnmarshal() -> ByteArray {
 			),
 		),
 	));
-	return bytearray_unmarshalBytes(marshalledStruct);
+	if let Some(ba) = bytearray_unmarshalBytes(marshalledStruct) {
+	    return ba;
+	} else {
+	    panic;
+	}
 }

--- a/stdlib/keccaktest.mini
+++ b/stdlib/keccaktest.mini
@@ -105,7 +105,11 @@ func setupFromUnmarshal() -> ByteArray {
 			),
 		),
 	));
-	return bytearray_unmarshalBytes(marshalledStruct);
+	if let Some(ba) = bytearray_unmarshalBytes(marshalledStruct) {
+	    return ba;
+	} else {
+	    panic;
+	}
 }
 
 func hasherMatches(ba: ByteArray) -> bool {

--- a/stdlib/rlptest.mini
+++ b/stdlib/rlptest.mini
@@ -62,41 +62,47 @@ impure func main(kind: uint, value: any) {
         }
     } elseif (kind == 1) {
         let mb = unsafecast<MarshalledBytes>(value);
-        let in = bytearray_unmarshalBytes(mb);
-        let encoded = rlp_encodeBytes(
-            in,
-            0,
-            bytearray_size(in),
-            bytearray_new(0),
-            0
-        ).0;
+        if let Some(in) = bytearray_unmarshalBytes(mb) {
+            let encoded = rlp_encodeBytes(
+                in,
+                0,
+                bytearray_size(in),
+                bytearray_new(0),
+                0
+            ).0;
 
-        // decode and verify no difference
-        if let Some(res) = rlp_decodeBytes(bytestream_new(encoded)) {
-            let marshDec = bytearray_marshalFull(res.1);
-            if (marshDec == mb) {
-                asm(bytearray_marshalFull(encoded),) { log };
+            // decode and verify no difference
+            if let Some(res) = rlp_decodeBytes(bytestream_new(encoded)) {
+                let marshDec = bytearray_marshalFull(res.1);
+                if (marshDec == mb) {
+                    asm(bytearray_marshalFull(encoded),) { log };
+                } else {
+                    asm( (20, bytearray_marshalFull(encoded)), ) { log };
+                }
             } else {
-                asm( (20, bytearray_marshalFull(encoded)), ) { log };
+                asm(3,) { log };
             }
         } else {
-            asm(3,) { log };
+            panic;
         }
     } elseif (kind == 2) {
         let vals = unsafecast<(uint, MarshalledBytes, uint)>(value);
-        let data = bytearray_unmarshalBytes(vals.1);
-        let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(3));  // workaround issue #120
-        encodedPieces = encodedPieces with {
-            [0] = rlp_encodeUint(vals.0, bytearray_new(0), 0).0
-        } with {
-            [1] = rlp_encodeBytes(data, 0, bytearray_size(data), bytearray_new(0), 0).0
-        } with {
-            [2] = rlp_encodeUint(vals.2, bytearray_new(0), 0).0
-        };
-        if let Some(res) = rlp_encodeList(encodedPieces, 0, 3, bytearray_new(0), 0) {
-            asm(bytearray_marshalFull(res.0),) { log };
+        if let Some(data) = bytearray_unmarshalBytes(vals.1) {
+            let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(3));  // workaround issue #120
+            encodedPieces = encodedPieces with {
+                [0] = rlp_encodeUint(vals.0, bytearray_new(0), 0).0
+            } with {
+                [1] = rlp_encodeBytes(data, 0, bytearray_size(data), bytearray_new(0), 0).0
+            } with {
+                [2] = rlp_encodeUint(vals.2, bytearray_new(0), 0).0
+            };
+            if let Some(res) = rlp_encodeList(encodedPieces, 0, 3, bytearray_new(0), 0) {
+                asm(bytearray_marshalFull(res.0),) { log };
+            } else {
+                asm(4,) { log };
+            }
         } else {
-            asm(4,) { log };
+            panic;
         }
     }
 


### PR DESCRIPTION
Cap the size of bytearrays at 2**64 bytes.  This eliminates weird behaviors associated with overflow of sizes and offsets.
* unmarshalling a byte stack that claims to be larger returns an error
* bytearray_set* ignores writes that would touch offsets >= 2**64 
* bytearray_copy shortens a copy if necessary so that the result fits within the limit

This PR also fixes some minor issues with duplicate error codes and unneeded use statements.