### PR TITLE
Change file_name_chart from HashMap to BTreeMap

### DIFF
--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -44,7 +44,7 @@ pub fn mavm_codegen(
     string_table: &StringTable,
     imported_funcs: &[ImportedFunc],
     global_vars: &[GlobalVarDecl],
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<Vec<Instruction>, CodegenError> {
     let mut import_func_map = HashMap::new();
     for imp_func in imported_funcs {
@@ -95,7 +95,7 @@ fn mavm_codegen_func(
     string_table: &StringTable,
     import_func_map: &HashMap<StringId, Label>,
     global_var_map: &HashMap<StringId, usize>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, Vec<Instruction>), CodegenError> {
     let mut code = vec![];
     let debug_info = func.debug_info;
@@ -166,7 +166,7 @@ fn add_args_to_locals_table(
     string_table: &StringTable,
     import_func_map: &HashMap<StringId, Label>,
     global_var_map: &HashMap<StringId, usize>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, usize, bool), CodegenError> {
     let mut locals_map = HashMap::new();
     for (index, arg) in args.iter().enumerate() {
@@ -210,7 +210,7 @@ fn mavm_codegen_statements(
     global_var_map: &HashMap<StringId, usize>,
     prepushed_vals: usize,
     scopes: &mut Vec<(String, Label, Option<Type>)>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, usize, bool, HashMap<StringId, usize>), CodegenError> {
     let mut bindings = HashMap::new();
     for statement in statements {
@@ -261,7 +261,7 @@ fn mavm_codegen_statement(
     global_var_map: &HashMap<StringId, usize>,
     prepushed_vals: usize,
     scopes: &mut Vec<(String, Label, Option<Type>)>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, usize, bool, HashMap<StringId, usize>), CodegenError> {
     let debug = statement.debug_info;
     let loc = statement.debug_info.location;
@@ -859,7 +859,7 @@ fn mavm_codegen_if_arm(
     global_var_map: &HashMap<StringId, usize>,
     prepushed_vals: usize,
     scopes: &mut Vec<(String, Label, Option<Type>)>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, usize, bool), CodegenError> {
     // (label_gen, num_labels, execution_might_continue)
     match arm {
@@ -992,7 +992,7 @@ fn mavm_codegen_expr<'a>(
     global_var_map: &HashMap<StringId, usize>,
     prepushed_vals: usize,
     scopes: &mut Vec<(String, Label, Option<Type>)>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, &'a mut Vec<Instruction>, usize), CodegenError> {
     let debug = expr.debug_info;
     let loc = expr.debug_info.location;
@@ -2023,7 +2023,7 @@ fn codegen_fixed_array_mod<'a>(
     debug_info: DebugInfo,
     prepushed_vals: usize,
     scopes: &mut Vec<(String, Label, Option<Type>)>,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<(LabelGenerator, &'a mut Vec<Instruction>, usize), CodegenError> {
     let (label_gen, code, val_locals) = mavm_codegen_expr(
         val_expr,

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -13,7 +13,7 @@ use lalrpop_util::lalrpop_mod;
 use mini::DeclsParser;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Formatter;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
@@ -240,7 +240,7 @@ impl CompiledProgram {
 /// file, and if debug is set to true, then compiler internal debug information will be printed.
 pub fn compile_from_file(
     path: &Path,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
     _debug: bool,
     inline: bool,
 ) -> Result<Vec<CompiledProgram>, CompileError> {
@@ -294,7 +294,7 @@ pub fn compile_from_folder(
     folder: &Path,
     library: Option<&str>,
     main: &str,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
     inline: bool,
 ) -> Result<Vec<CompiledProgram>, CompileError> {
     let (mut programs, import_map) = create_program_tree(folder, library, main, file_name_chart)?;
@@ -492,7 +492,7 @@ fn create_program_tree(
     folder: &Path,
     library: Option<&str>,
     main: &str,
-    file_name_chart: &mut HashMap<u64, String>,
+    file_name_chart: &mut BTreeMap<u64, String>,
 ) -> Result<
     (
         HashMap<Vec<String>, Module>,

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -108,22 +108,28 @@ impl AbiForContract {
         };
 
         let (request_id, sender_addr) = if let Some(buddy_addr) = address_for_buddy.clone() {
-            (machine.runtime_env.insert_buddy_deploy_message(
-                buddy_addr.clone(),
-                Uint256::from_usize(1_000_000_000_000),
-                Uint256::zero(),
-                payment,
-                &augmented_code,
-            ), buddy_addr)
+            (
+                machine.runtime_env.insert_buddy_deploy_message(
+                    buddy_addr.clone(),
+                    Uint256::from_usize(1_000_000_000_000),
+                    Uint256::zero(),
+                    payment,
+                    &augmented_code,
+                ),
+                buddy_addr,
+            )
         } else {
-            (machine.runtime_env.insert_tx_message(
+            (
+                machine.runtime_env.insert_tx_message(
+                    Uint256::from_u64(1025),
+                    Uint256::from_usize(1_000_000_000_000),
+                    Uint256::zero(),
+                    Uint256::zero(),
+                    payment,
+                    &augmented_code,
+                ),
                 Uint256::from_u64(1025),
-                Uint256::from_usize(1_000_000_000_000),
-                Uint256::zero(),
-                Uint256::zero(),
-                payment,
-                &augmented_code,
-            ), Uint256::from_u64(1025))
+            )
         };
 
         let _gas_used = if debug {
@@ -457,7 +463,8 @@ pub struct ArbAddressTable<'a> {
 impl<'a> ArbAddressTable<'a> {
     pub fn new(wallet: &'a Wallet, debug: bool) -> Self {
         let mut contract_abi =
-            AbiForContract::new_from_file("contracts/add/build/contracts/ArbAddressTable.json").unwrap();
+            AbiForContract::new_from_file("contracts/add/build/contracts/ArbAddressTable.json")
+                .unwrap();
         contract_abi.bind_interface_to_address(Uint256::from_u64(102));
         ArbAddressTable {
             contract_abi,
@@ -502,19 +509,11 @@ impl<'a> ArbAddressTable<'a> {
         }
     }
 
-    pub fn register(
-        &self,
-        machine: &mut Machine,
-        addr: Uint256,
-    ) -> Result<Uint256, ethabi::Error> {
+    pub fn register(&self, machine: &mut Machine, addr: Uint256) -> Result<Uint256, ethabi::Error> {
         self.addr_to_uint_tx("register", machine, addr)
     }
 
-    pub fn lookup(
-        &self,
-        machine: &mut Machine,
-        addr: Uint256,
-    ) -> Result<Uint256, ethabi::Error> {
+    pub fn lookup(&self, machine: &mut Machine, addr: Uint256) -> Result<Uint256, ethabi::Error> {
         self.addr_to_uint_tx("lookup", machine, addr)
     }
 
@@ -619,11 +618,7 @@ impl<'a> ArbAddressTable<'a> {
         }
     }
 
-    pub fn compress(
-        &self,
-        machine: &mut Machine,
-        addr: Uint256,
-    ) -> Result<Vec<u8>, ethabi::Error> {
+    pub fn compress(&self, machine: &mut Machine, addr: Uint256) -> Result<Vec<u8>, ethabi::Error> {
         let (receipts, sends) = self.contract_abi.call_function(
             self.my_address.clone(),
             "compress",
@@ -761,7 +756,8 @@ pub struct ArbFunctionTable<'a> {
 impl<'a> ArbFunctionTable<'a> {
     pub fn new(wallet: &'a Wallet, debug: bool) -> Self {
         let mut contract_abi =
-            AbiForContract::new_from_file("contracts/add/build/contracts/ArbFunctionTable.json").unwrap();
+            AbiForContract::new_from_file("contracts/add/build/contracts/ArbFunctionTable.json")
+                .unwrap();
         contract_abi.bind_interface_to_address(Uint256::from_u64(104));
         ArbFunctionTable {
             contract_abi,
@@ -795,11 +791,7 @@ impl<'a> ArbFunctionTable<'a> {
         Ok(())
     }
 
-    pub fn size(
-        &self,
-        machine: &mut Machine,
-        addr: Uint256,
-    ) -> Result<Uint256, ethabi::Error> {
+    pub fn size(&self, machine: &mut Machine, addr: Uint256) -> Result<Uint256, ethabi::Error> {
         self.addr_to_uint_tx("size", machine, addr)
     }
 

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -2,8 +2,8 @@
  * Copyright 2020, Offchain Labs, Inc. All rights reserved.
  */
 
-use crate::evm::abi::{ArbSys, ArbAddressTable, ArbBLS, ArbFunctionTable};
 use crate::evm::abi::FunctionTable;
+use crate::evm::abi::{ArbAddressTable, ArbBLS, ArbFunctionTable, ArbSys};
 use crate::mavm::Value;
 use crate::run::{bytestack_from_bytes, load_from_file, RuntimeEnvironment};
 use crate::uint256::Uint256;
@@ -175,10 +175,7 @@ pub fn evm_test_arbsys_direct(log_to: Option<&Path>, debug: bool) -> Result<(), 
     assert_eq!(my_addr.clone(), my_addr_decompressed);
     assert_eq!(offset, Uint256::from_usize(my_addr_compressed.len()));
 
-    assert_eq!(
-        Uint256::from_u64(2),
-        arb_address_table.size(&mut machine)?
-    );
+    assert_eq!(Uint256::from_u64(2), arb_address_table.size(&mut machine)?);
 
     let an_addr = Uint256::from_u64(581351734971918347);
     let an_addr_compressed = arb_address_table.compress(&mut machine, an_addr.clone())?;
@@ -566,7 +563,13 @@ pub fn evm_deploy_buddy_contract(log_to: Option<&Path>, debug: bool) {
 
     match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), Some(Uint256::from_u64(1025)), debug);
+            let result = contract.deploy(
+                &[],
+                &mut machine,
+                Uint256::zero(),
+                Some(Uint256::from_u64(1025)),
+                debug,
+            );
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
             } else {
@@ -603,13 +606,8 @@ pub fn evm_test_payment_in_constructor(log_to: Option<&Path>, debug: bool) {
 
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(
-                &vec![],
-                &mut machine,
-                Uint256::from_u64(10000),
-                None,
-                debug,
-            );
+            let result =
+                contract.deploy(&vec![], &mut machine, Uint256::from_u64(10000), None, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract
@@ -816,24 +814,31 @@ pub fn _evm_test_same_address_deploy(log_to: Option<&Path>, debug: bool) {
     machine.start_at_zero();
 
     let my_addr = Uint256::from_usize(1025);
-    let (contract, orig_contract_addr) = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
-        Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
-            if let Some(contract_addr) = result {
-                assert_ne!(contract_addr, Uint256::zero());
-                (contract, contract_addr)
-            } else {
-                panic!("deploy failed");
+    let (contract, orig_contract_addr) =
+        match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
+            Ok(mut contract) => {
+                let result = contract.deploy(&[], &mut machine, Uint256::zero(), None, debug);
+                if let Some(contract_addr) = result {
+                    assert_ne!(contract_addr, Uint256::zero());
+                    (contract, contract_addr)
+                } else {
+                    panic!("deploy failed");
+                }
             }
-        }
-        Err(e) => {
-            panic!("error loading contract: {:?}", e);
-        }
-    };
+            Err(e) => {
+                panic!("error loading contract: {:?}", e);
+            }
+        };
 
     match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut new_contract) => {
-            let result = new_contract.deploy(&[], &mut machine, Uint256::zero(), Some(orig_contract_addr), debug);
+            let result = new_contract.deploy(
+                &[],
+                &mut machine,
+                Uint256::zero(),
+                Some(orig_contract_addr),
+                debug,
+            );
             assert_eq!(result, None);
         }
         Err(e) => {
@@ -848,7 +853,7 @@ pub fn _evm_test_same_address_deploy(log_to: Option<&Path>, debug: bool) {
             ethabi::Token::Uint(ethabi::Uint::one()),
             ethabi::Token::Uint(ethabi::Uint::one()),
         ]
-            .as_ref(),
+        .as_ref(),
         &mut machine,
         Uint256::zero(),
         debug,

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -11,6 +11,7 @@ use crate::mavm::{AVMOpcode, CodePt, Instruction, Label, Opcode, Value};
 use crate::stringtable::{StringId, StringTable};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::{DefaultHasher, HashMap};
+use std::collections::BTreeMap;
 use std::hash::Hasher;
 use std::io;
 use std::path::Path;
@@ -31,7 +32,7 @@ pub struct LinkedProgram {
     pub static_val: Value,
     pub exported_funcs: Vec<ExportedFuncPoint>,
     pub imported_funcs: Vec<ImportedFunc>,
-    pub file_name_chart: HashMap<u64, String>,
+    pub file_name_chart: BTreeMap<u64, String>,
 }
 
 impl LinkedProgram {
@@ -200,7 +201,7 @@ pub fn postlink_compile(
     program: CompiledProgram,
     is_module: bool,
     evm_pcs: Vec<usize>, // ignored unless we're in a module
-    mut file_name_chart: HashMap<u64, String>,
+    mut file_name_chart: BTreeMap<u64, String>,
     debug: bool,
 ) -> Result<LinkedProgram, CompileError> {
     if debug {
@@ -287,7 +288,7 @@ pub fn add_auto_link_progs(
     let mut progs = progs_in.to_owned();
     for pathname in builtin_pathnames.into_iter() {
         let path = Path::new(pathname);
-        match compile_from_file(path, &mut HashMap::new(), false, false) {
+        match compile_from_file(path, &mut BTreeMap::new(), false, false) {
             Ok(compiled_program) => {
                 compiled_program
                     .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use contracttemplates::generate_contract_template_file_or_die;
 use link::{link, postlink_compile};
 use mavm::Value;
 use run::{profile_gen_from_file, replay_from_testlog_file, run_from_file, RuntimeEnvironment};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io;
 use std::path::Path;
@@ -104,7 +104,7 @@ fn main() -> Result<(), CompileError> {
             let typecheck = compile.typecheck;
             let mut output = get_output(compile.output.as_deref()).unwrap();
             let filenames: Vec<_> = compile.input.clone();
-            let mut file_name_chart = HashMap::new();
+            let mut file_name_chart = BTreeMap::new();
             if compile.compile_only {
                 let filename = &filenames[0];
                 let path = Path::new(filename);

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -358,7 +358,7 @@ pub struct ProfilerData {
     data: HashMap<String, BTreeMap<(usize, usize), u64>>,
     stack_tree: HashMap<CodePt, (Vec<ProfilerEvent>, Option<Location>)>,
     unknown_gas: u64,
-    file_name_chart: HashMap<u64, String>,
+    file_name_chart: BTreeMap<u64, String>,
 }
 
 impl ProfilerData {
@@ -369,7 +369,7 @@ impl ProfilerData {
     fn get_mut(
         &mut self,
         loc: &Option<Location>,
-        chart: &HashMap<u64, String>,
+        chart: &BTreeMap<u64, String>,
     ) -> Option<&mut u64> {
         if let Some(loc) = loc {
             let filename = chart.get(&loc.file_id)?;
@@ -388,7 +388,7 @@ impl ProfilerData {
         &mut self,
         loc: &Option<Location>,
         gas: u64,
-        chart: &HashMap<u64, String>,
+        chart: &BTreeMap<u64, String>,
     ) -> Option<u64> {
         if let Some(loc) = loc {
             let filename = match chart.get(&loc.file_id) {
@@ -673,7 +673,7 @@ pub struct Machine {
     err_codepoint: CodePt,
     arb_gas_remaining: Uint256,
     pub runtime_env: RuntimeEnvironment,
-    file_name_chart: HashMap<u64, String>,
+    file_name_chart: BTreeMap<u64, String>,
     total_gas_usage: Uint256,
     trace_writer: Option<BufWriter<File>>,
 }


### PR DESCRIPTION
This fixes the lack of determinism in the compiler output.  Previous versions would have different orders for files in the file name chart, but were otherwise deterministic.