### PR TITLE
Use recursive types in the mini code and remove unused files

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -108,8 +108,7 @@ type EvmCallFrame = struct {
     selfDestructQueue: Queue,           // set of self-destruct directives, including those created by this call and its subcalls
     resumeInfo: option<ResumeInfo>,     // if call is suspended, its state will be saved here
     sendQueue: Queue,                   // outgoing messages, including those created by this call and its subcalls
-    parent: option<any>,                // call-frame that created this one, or None if this is a top-level call
-                      // parent is really an option<EvmCallFrame>, but compiler doesn't allow recursive types
+    parent: option<EvmCallFrame>,                // call-frame that created this one, or None if this is a top-level call
 }
 
 type ReturnInfo = struct {  // information about a call that previously completed
@@ -207,7 +206,7 @@ public impure func initEvmCallStack(
                     selfDestructQueue: queue_new(),
                     resumeInfo: None<ResumeInfo>,
                     sendQueue: queue_new(),
-                    parent: None<any>
+                    parent: None<EvmCallFrame>
                 });
 
                 emptyAvmStack();
@@ -321,7 +320,7 @@ public impure func initEvmCallStackForConstructor(
             selfDestructQueue: queue_new(),
             resumeInfo: None<ResumeInfo>,
             sendQueue: queue_new(),
-            parent: None<any>
+            parent: None<EvmCallFrame>
         });
 
         if (gasAccounting_startTxCharges(request.maxGas, request.gasPrice, request.caller) != None<()>) {
@@ -1039,9 +1038,7 @@ public func evmCallFrame_getSelfDestructQueue(frame: EvmCallFrame) -> Queue {
 }
 
 public func evmCallFrame_getParent(frame: EvmCallFrame) -> option<EvmCallFrame> {
-    return unsafecast<option<EvmCallFrame>>(frame.parent);
-    // unsafecast is safe because underlying type is really EvmCallFrame
-    //    (compiler doesn't know because it doesn't accept recursive types)
+    return frame.parent;
 }
 
 public impure func evmCallStack_callHitError(errInfo: any) {

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -465,7 +465,7 @@ public impure func evmCallStack_returnFromCall(
     let memory = topFrame.memory;
     let returnData = bytearray_extract(memory, returnOffset, returnLength);
 
-    if let Some(newTopFrame) = unsafecast<option<EvmCallFrame>>(topFrame.parent) {
+    if let Some(newTopFrame) = topFrame.parent {
         // Returning from a non-top-level call
 
         topFrame = topFrame with {   // copy cached account back into callframe's main accountStore
@@ -798,8 +798,7 @@ public impure func evmCallStack_oldestCallFrame() -> option<EvmCallFrame> {
     let frame = globalCallStack?;
     loop {
         if let Some(parent) = frame.parent {
-            // do "unsafe" cast because compiler doesn't know the true type of parent
-            frame = unsafecast<EvmCallFrame>(parent);
+            frame = parent;
         } else {
             return Some(frame);
         }

--- a/builtin/kvs.mini
+++ b/builtin/kvs.mini
@@ -98,7 +98,7 @@ public func builtin_kvsSet(s: Kvs, key: any, value: any) -> Kvs {
             utree = unwinder.kvs with {
                 [unwinder.index] = utree
             };
-            maybeUnwinder = unsafecast<option<Unwinder>>(unwinder.next);
+            maybeUnwinder = unwinder.next;
         } else {
             if (delta != int(0)) {
                 s = s with { size: uint(int(s.size) + delta) };
@@ -180,7 +180,7 @@ public func builtin_kvsDelete(s: Kvs, key: uint) -> Kvs {
             utree = unwinder.kvs with {
                 [unwinder.index] = utree
             };
-            maybeUnwinder = unsafecast<option<Unwinder>>(unwinder.next);
+            maybeUnwinder = unwinder.next;
         } else {
             if (delta != int(0)) {
                 s = s with { size: uint(int(s.size) + delta) };

--- a/builtin/kvs.mini
+++ b/builtin/kvs.mini
@@ -88,7 +88,7 @@ public func builtin_kvsHasKey(kvs: Kvs, key: any) -> bool {
 type Unwinder = struct {
     kvs: [8]any,
     index: uint,
-    next: option<any>,   // really option<Unwinder>, but compiler doesn't do recursive types
+    next: option<Unwinder>,
 }
 
 public func builtin_kvsSet(s: Kvs, key: any, value: any) -> Kvs {

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -54,7 +54,7 @@ public func marshalledBytes_firstByte(mb: MarshalledBytes) -> uint {
         return 0;
     }
     while (nbytes > 32) {
-        contents = unsafecast<MarshalledBytesCell>(contents.rest);
+        contents = contents.rest;
         nbytes = nbytes-32;
     }
     return asm(256-8, contents.first) uint { shr };
@@ -96,7 +96,7 @@ public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> option<ByteArr
             eia = expandingIntArray_setN(eia, 8, nwords, block);
             // it's safe to re-use block after this, because we're going to overwrite all of it
         }
-        words = unsafecast<MarshalledBytesCell>(words.rest);
+        words = words.rest;
     }
 
     return Some(struct {

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -44,7 +44,7 @@ type MarshalledBytes = struct {
 
 type MarshalledBytesCell = struct {
     first: uint,
-    rest: any,  // really a MarshalledbytesCell, but compiler can't handle recursive types
+    rest: MarshalledBytesCell,
 }
 
 public func marshalledBytes_firstByte(mb: MarshalledBytes) -> uint {

--- a/stdlib/expandingIntArray.mini
+++ b/stdlib/expandingIntArray.mini
@@ -103,7 +103,7 @@ public func expandingIntArray_setN(
             loop {
                 if let Some(unw) = unwinder {
                     tree = unw.tree with { [unw.slot] = tree };
-                    unwinder = unsafecast<option<Unwinder>>(unw.next);
+                    unwinder = unw.next;
                 } else {
                     return arr with { contents: tree };
                 }

--- a/stdlib/expandingIntArray.mini
+++ b/stdlib/expandingIntArray.mini
@@ -73,7 +73,7 @@ func ear_get_2(tree: [8]any, chunk: uint, index: uint) -> uint {
 type Unwinder = struct {
     tree: [8]any,
     slot: uint,
-    next: option<any>,  // really option<Unwinder>, but compiler doesn't allow recursive types
+    next: option<Unwinder>,
 }
 
 public func expandingIntArray_set(arr: ExpandingIntArray, index: uint, value: uint) -> ExpandingIntArray {

--- a/stdlib/stack.mini
+++ b/stdlib/stack.mini
@@ -7,7 +7,7 @@ type Stack = option<StackCell>
 type StackCell = struct {
     top: [8]any,
     num: uint,
-    rest: option<any>   // really option<StackCell>, but compiler doesn't support recursive types
+    rest: option<StackCell>
 }
 
 

--- a/stdlib/storageMap.mini
+++ b/stdlib/storageMap.mini
@@ -94,7 +94,7 @@ public func storageMap_set(s: StorageMap, key: uint, value: uint) -> StorageMap 
             utree = unwinder.kvs with {
                 [unwinder.index] = utree
             };
-            maybeUnwinder = unsafecast<option<Unwinder>>(unwinder.next);
+            maybeUnwinder = unwinder.next;
         } else {
             if (delta != int(0)) {
                 s = s with { size: uint(int(s.size) + delta) };

--- a/stdlib/storageMap.mini
+++ b/stdlib/storageMap.mini
@@ -84,7 +84,7 @@ public func storageMap_get(kvs: StorageMap, key: uint) -> uint {
 type Unwinder = struct {
     kvs: [8]any,
     index: uint,
-    next: option<any>,   // really option<Unwinder>, but compiler doesn't do recursive types
+    next: option<Unwinder>,
 }
 
 public func storageMap_set(s: StorageMap, key: uint, value: uint) -> StorageMap {


### PR DESCRIPTION
This changes fields of type `any` to recursive types to improve type safety.