### PR TITLE
Fix EC precompiles

### DIFF
--- a/arb_os/precompiles.mini
+++ b/arb_os/precompiles.mini
@@ -177,9 +177,6 @@ public impure func precompile_0x04() {  // identity function
 public impure func precompile_0x06() {  // ecadd
     if let Some(topFrame) = evmCallStack_topFrame() {
         let calldata = evmCallFrame_getCalldata(topFrame);
-        if (bytearray_size(calldata) != 4*32) {
-            evmOp_revert_knownPc(0, 0, 0);
-        }
         let x0 = bytearray_get256(calldata, 0);
         let x1 = bytearray_get256(calldata, 32);
         let y0 = bytearray_get256(calldata, 2*32);
@@ -210,9 +207,6 @@ public impure func precompile_0x06() {  // ecadd
 public impure func precompile_0x07() {  // ecmul
     if let Some(topFrame) = evmCallStack_topFrame() {
         let calldata = evmCallFrame_getCalldata(topFrame);
-        if (bytearray_size(calldata) != 3*32) {
-            evmOp_revert_knownPc(0, 0, 0);
-        }
         let x0 = bytearray_get256(calldata, 0);
         let x1 = bytearray_get256(calldata, 32);
         let n = bytearray_get256(calldata, 2*32);


### PR DESCRIPTION
Currently the ECADD and ECMUL precompiles are implemented to revert when the input is not 128 bytes. Instead the function should support any input size, filling with zeros for reads beyond the input