### PR TITLE
Handle unknown default values rather than panicking

### DIFF
--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -1633,7 +1633,7 @@ fn mavm_codegen_expr<'a>(
                 vec![Type::Uint, Type::Any],
                 Box::new(array_type.clone()),
             );
-            let default_val = base_type.default_value().unwrap_or(Value::none());
+            let (default_val, _is_safe) = base_type.default_value();
             let the_expr = TypeCheckedExpr {
                 kind: TypeCheckedExprKind::FunctionCall(
                     Box::new(TypeCheckedExpr {

--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -1633,7 +1633,7 @@ fn mavm_codegen_expr<'a>(
                 vec![Type::Uint, Type::Any],
                 Box::new(array_type.clone()),
             );
-            let default_val = base_type.default_value();
+            let default_val = base_type.default_value().unwrap_or(Value::none());
             let the_expr = TypeCheckedExpr {
                 kind: TypeCheckedExprKind::FunctionCall(
                     Box::new(TypeCheckedExpr {


### PR DESCRIPTION
Change `Type::default_value` to return a pair `(defaultValue, isTypeSafe)` rather than panicking when there isn't a known default value. This allows the code generator to (correctly, according to the Mini spec) create new arrays of any type, with the array slots being uninitialized if the type doesn't have a default value.
