### PR TITLE
Fix staticcall behavior

### DIFF
--- a/arb_os/decompression.mini
+++ b/arb_os/decompression.mini
@@ -328,6 +328,7 @@ impure func decompressTx(
             value: value,
             calldata: calldata,
             nonMutating: false,
+            isConstructor: (toAddr == address(0)),
             incomingRequest: unsafecast<IncomingRequest>(0),  // caller will fill this in
         }
     ));

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -98,7 +98,7 @@ type EvmCallFrame = struct {
     accountStore: AccountStore,         // accountStore used for executing this call
     runningAsAccount: Account,          // cache of accountStore[runningAs]
     caller: address,                    // who called this
-    callKind: uint,                     // type of call: 0=call, 2=delegatecall, 3=staticcall, 4=constructor
+    static: bool,                       // static flag, per EIP-214
     calldata: ByteArray,                // calldata passed in by our caller
     callvalue: uint,                    // Eth value given to this call by its caller
     returnInfo: option<ReturnInfo>,     // result of last subcall made by this call (if any)
@@ -168,6 +168,7 @@ type TxRequestData = struct {
     value: uint,
     calldata: ByteArray,
     nonMutating: bool,
+    isConstructor: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -213,7 +214,7 @@ public impure func initEvmCallStack(
                     accountStore: globalAS,
                     runningAsAccount: accountStore_get(globalAS, request.calleeAddr),
                     caller: request.caller,
-                    callKind: callKind,
+                    static: false,
                     calldata: request.calldata,
                     callvalue: request.value,
                     returnInfo: None<ReturnInfo>,
@@ -338,7 +339,7 @@ public impure func initEvmCallStackForConstructor(
     // The constructor will run, and (if it succeeds) it will return code, which will become the new
     //      code for this new account.
 
-    globalCurrentTxRequest = request;
+    globalCurrentTxRequest = request with { isConstructor: true };
 
     // Create a new account to run the constructor code.
     let acctStore = accountStore_set(
@@ -363,7 +364,7 @@ public impure func initEvmCallStackForConstructor(
             accountStore: acctStore,
             runningAsAccount: accountStore_get(acctStore, request.calleeAddr),
             caller: request.caller,
-            callKind: const::EVMCallType_constructor,
+            static: false,
             calldata: request.calldata,
             callvalue: 0,
             returnInfo: None<ReturnInfo>,
@@ -469,7 +470,7 @@ public impure func evmCallStack_doCall(
                 calleeAddr,
                 balance
             )?;
-        } elseif (kind == const::EVMCallType_staticcall) {
+        } elseif (kind == const::EVMCallType_delegatecall) {
             // delegatecall inherits the callvalue of its parent
             // but don't do a transfer because it's running as the same account
             balance = topFrame.callvalue;
@@ -480,7 +481,7 @@ public impure func evmCallStack_doCall(
             accountStore: updatedAcctStore,
             runningAsAccount: accountStore_get(updatedAcctStore, runningAsAddr),
             caller: newCallerAddr,
-            callKind: kind,
+            static: topFrame.static || (kind == const::EVMCallType_staticcall),
             calldata: bytearray_extract(topFrame.memory, argsOffset, argsLength),
             callvalue: balance,
             returnInfo: None<ReturnInfo>,
@@ -541,7 +542,7 @@ public impure func evmCallStack_returnFromCall(
             )
         };
 
-        if (success && (topFrame.callKind != const::EVMCallType_staticcall)) {
+        if (success && !topFrame.static) {
             // copy relevant data back to parent frame
             newTopFrame = newTopFrame
                 with { accountStore: topFrame.accountStore }
@@ -582,7 +583,7 @@ public impure func evmCallStack_returnFromCall(
         // top-level call completed; will need to return to external caller
         let gasUsage = gasAccounting_endTxCharges()?;
         if (success) {
-            if (topFrame.callKind == const::EVMCallType_constructor) {
+            if (globalCurrentTxRequest.isConstructor) {
                 // Constructor call was successful, so finish setting up the account.
                 // The constructor's returndata is EVM code for the contract.
                 // Compile that EVM code into AVM, and substitute that in as the code for the contract.
@@ -667,7 +668,7 @@ public impure func evmCallStack_returnFromCall(
                     }
                 }
             } else {
-                if (topFrame.callKind != const::EVMCallType_staticcall) {
+                if (! globalCurrentTxRequest.nonMutating) {
                     // It was a successful tx (not a non-mutating call).
                     // We'll commit the results of the tx
 

--- a/arb_os/evmOps.mini
+++ b/arb_os/evmOps.mini
@@ -464,6 +464,9 @@ public impure func evmOp_sload(storageAddr: uint) -> uint {
 
 public impure func evmOp_sstore(storageAddr: uint, value: uint) {
     if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
         if (evmCallFrame_shouldRevertOnStorageWrite(topFrame)) {
             // the currently running code was given a gas amount that wouldn't allow a storage write on EVM
             // for compatibility with EVM code that uses gas limit to prevent writes, we cause out-of-gas error here
@@ -517,18 +520,23 @@ public impure func evmOp_log0(
     memAddr: uint, 
     nbytes: uint
 ) {
-    let data = bytearray_extract(
-        evmCallStack_getTopFrameMemoryOrDie(),
-        memAddr,
-        nbytes
-    );
-    if (evmCallStack_addEvmLogToCurrent(
-        (
-            address(0),  // addEvmLogToCurrent will fill this in
-            bytearray_marshalFull(data),
-        )
-    ) == Some(()) ) {
-        return;
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let data = bytearray_extract(
+            evmCallFrame_getMemory(topFrame),
+            memAddr,
+            nbytes
+        );
+        if (evmCallStack_addEvmLogToCurrent(
+            (
+                address(0),  // addEvmLogToCurrent will fill this in
+                bytearray_marshalFull(data),
+            )
+        ) == Some(()) ) {
+            return;
+        }
     }
 
     evm_runtimePanic(23);
@@ -540,19 +548,24 @@ public impure func evmOp_log1(
     nbytes: uint, 
     topic0: uint
 ) {
-    let data = bytearray_extract(
-        evmCallStack_getTopFrameMemoryOrDie(),
-        memAddr,
-        nbytes
-    );
-    if (evmCallStack_addEvmLogToCurrent(
-        (
-            address(0),  // addEvmLogToCurrent will fill this in
-            bytearray_marshalFull(data),
-            topic0
-        )
-    ) == Some(()) ) {
-        return;
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let data = bytearray_extract(
+            evmCallFrame_getMemory(topFrame),
+            memAddr,
+            nbytes
+        );
+        if (evmCallStack_addEvmLogToCurrent(
+            (
+                address(0),  // addEvmLogToCurrent will fill this in
+                bytearray_marshalFull(data),
+                topic0,
+            )
+        ) == Some(()) ) {
+            return;
+        }
     }
 
     evm_runtimePanic(24);
@@ -565,20 +578,25 @@ public impure func evmOp_log2(
     topic0: uint,
     topic1: uint,
 ) {
-    let data = bytearray_extract(
-        evmCallStack_getTopFrameMemoryOrDie(),
-        memAddr,
-        nbytes
-    );
-    if (evmCallStack_addEvmLogToCurrent(
-        (
-            address(0),  // addEvmLogToCurrent will fill this in
-            bytearray_marshalFull(data),
-            topic0,
-            topic1
-        )
-    ) == Some(()) ) {
-        return;
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let data = bytearray_extract(
+            evmCallFrame_getMemory(topFrame),
+            memAddr,
+            nbytes
+        );
+        if (evmCallStack_addEvmLogToCurrent(
+            (
+                address(0),  // addEvmLogToCurrent will fill this in
+                bytearray_marshalFull(data),
+                topic0,
+                topic1,
+            )
+        ) == Some(()) ) {
+            return;
+        }
     }
 
     evm_runtimePanic(25);
@@ -592,21 +610,26 @@ public impure func evmOp_log3(
     topic1: uint,
     topic2: uint,
 ) {
-    let data = bytearray_extract(
-        evmCallStack_getTopFrameMemoryOrDie(),
-        memAddr,
-        nbytes
-    );
-    if (evmCallStack_addEvmLogToCurrent(
-        (
-            address(0),  // addEvmLogToCurrent will fill this in
-            bytearray_marshalFull(data),
-            topic0,
-            topic1,
-            topic2
-        )
-    ) == Some(()) ) {
-        return;
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let data = bytearray_extract(
+            evmCallFrame_getMemory(topFrame),
+            memAddr,
+            nbytes
+        );
+        if (evmCallStack_addEvmLogToCurrent(
+            (
+                address(0),  // addEvmLogToCurrent will fill this in
+                bytearray_marshalFull(data),
+                topic0,
+                topic1,
+                topic2,
+            )
+        ) == Some(()) ) {
+            return;
+        }
     }
 
     evm_runtimePanic(26);
@@ -621,22 +644,27 @@ public impure func evmOp_log4(
     topic2: uint,
     topic3: uint,
 ) {
-    let data = bytearray_extract(
-        evmCallStack_getTopFrameMemoryOrDie(),
-        memAddr,
-        nbytes
-    );
-    if (evmCallStack_addEvmLogToCurrent(
-        (
-            address(0),  // addEvmLogToCurrent will fill this in
-            bytearray_marshalFull(data),
-            topic0,
-            topic1,
-            topic2,
-            topic3
-        )
-    ) == Some(()) ) {
-        return;
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let data = bytearray_extract(
+            evmCallFrame_getMemory(topFrame),
+            memAddr,
+            nbytes
+        );
+        if (evmCallStack_addEvmLogToCurrent(
+            (
+                address(0),  // addEvmLogToCurrent will fill this in
+                bytearray_marshalFull(data),
+                topic0,
+                topic1,
+                topic2,
+                topic3,
+            )
+        ) == Some(()) ) {
+            return;
+        }
     }
 
     evm_runtimePanic(27);
@@ -700,6 +728,16 @@ public impure func evmOp_call(
     retOffset: uint,
     retLength: uint
 ) -> bool {
+    if (balance > 0) {
+        if let Some(topFrame) = evmCallStack_topFrame() {
+            if (topFrame.static) {
+                evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+            }
+        } else {
+            evm_runtimePanic(34);
+        }
+    }
+
     let callee = address(calleeAsUint);  // truncates if necessary
 
     // First, get the return address of our caller.
@@ -881,14 +919,24 @@ public impure func evmOp_return(memOffset: uint, memNbytes: uint) {
 }
 
 public impure func evmOp_selfdestruct(ownerAsUint: uint) {
-    let owner = address(ownerAsUint);     // truncates if necessary
+    if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
+        let owner = address(ownerAsUint);     // truncates if necessary
 
-    evmCallStack_selfDestructCurrentAccount(owner,);
-    evmOp_return(0, 0);
+        evmCallStack_selfDestructCurrentAccount(owner,);
+        evmOp_return(0, 0);
+    } else {
+        evm_runtimePanic(33);
+    }
 }
 
 public impure func evmOp_create(value: uint, offset: uint, length: uint) -> address {
     if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
         let myAcct = evmCallFrame_runningAsAccount(topFrame);
         let myAddr = account_getAddress(myAcct);
         let (seqNum, updatedAcct) = account_fetchAndIncrSeqNum(myAcct);
@@ -905,6 +953,9 @@ public impure func evmOp_create(value: uint, offset: uint, length: uint) -> addr
 
 public impure func evmOp_create2(value: uint, offset: uint, length: uint, salt: uint) -> address {
     if let Some(topFrame) = evmCallStack_topFrame() {
+        if (topFrame.static) {
+            evmOp_revert_knownPc(0xfffffffffffffffe, 0, 0);
+        }
         let myAcct = evmCallFrame_runningAsAccount(topFrame);
         let myAddr = account_getAddress(myAcct);
         let newAddrBuf = bytearray_new(85);

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -241,6 +241,7 @@ type TxRequestData = struct {
     value: uint,
     calldata: ByteArray,
     nonMutating: bool,
+    isConstructor: bool,
     incomingRequest: IncomingRequest,
 }
 

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -366,6 +366,7 @@ impure func translateUnsignedTx(request: IncomingRequest) -> option<TxRequestDat
             value: value,
             calldata: calldata,
             nonMutating: (subtype == const::L2MessageType_nonmutatingCall),
+            isConstructor: (destAddrAsUint == 0),
             incomingRequest: request
         }
     );
@@ -395,6 +396,7 @@ func translateBuddyDeployTx(request: IncomingRequest) -> option<TxRequestData> {
             value: value,
             calldata: calldata,
             nonMutating: false,
+            isConstructor: true,
             incomingRequest: request
         }
     );

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -170,6 +170,7 @@ type TxRequestData = struct {
     value: uint,
     calldata: ByteArray,
     nonMutating: bool,
+    isConstructor: bool,
     incomingRequest: IncomingRequest,
 }
 

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -40,6 +40,7 @@ type TxRequestData = struct {
     value: uint,
     calldata: ByteArray,
     nonMutating: bool,
+    isConstructor: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -82,6 +83,7 @@ public impure func translateSignedTx(req: IncomingRequest) -> option<TxRequestDa
             value: signedTx.value,
             calldata: signedTx.data,
             nonMutating: false,
+            isConstructor: (signedTx.to == address(0)),
             incomingRequest: req with {
                 sender: signer
             } with {

--- a/arb_os/tokens.mini
+++ b/arb_os/tokens.mini
@@ -30,6 +30,7 @@ type TxRequestData = struct {
     value: uint,
     calldata: ByteArray,
     nonMutating: bool,
+    isConstructor: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -65,6 +66,7 @@ public impure func tokens_erc20deposit(
             value: 0,
             calldata: calldata,
             nonMutating: false,
+            isConstructor: false,
             incomingRequest: fullMsg,
         }
     );  // should never return
@@ -104,6 +106,7 @@ public impure func tokens_erc721deposit(
             value: 0,
             calldata: calldata,
             nonMutating: false,
+            isConstructor: false,
             incomingRequest: fullMsg,
         }
     );  // should never return


### PR DESCRIPTION
Change the behavior of STATICCALL EVM instruction to be consistent with EIP-214.  Track a static flag in each EVM call frame, and revert on mutating operations if the static flag is set.  This required some minor refactoring.