### PR TITLE
Eliminate imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ $(STDDIR)/bytearraytest.mexe: $(STDDIR)/bytearraytest.mini
 minitests/codeloadtest.mexe: minitests/codeloadtest.mini
 	$(CARGORUN) compile minitests/codeloadtest.mini -o minitests/codeloadtest.mexe
 
-$(STDDIR)/keccaktest.mexe: $(STDDIR)/keccaktest.mini
-	$(CARGORUN) compile $(STDDIR)/keccaktest.mini $(STDDIR)/keccak.mao $(STDDIR)/bytearray.mao $(STDDIR)/expandingIntArray.mao -o $(STDDIR)/keccaktest.mexe
+$(STDDIR)/keccaktest.mexe: $(STDDIR)/keccaktest.mini $(STDDIR)/keccak.mini $(STDDIR)/bytearray.mini $(STDDIR)/expandingIntArray.mini
+	$(CARGORUN) compile $(STDDIR)/keccaktest.mini -o $(STDDIR)/keccaktest.mexe
 
 $(STDDIR)/biguinttest.mexe: $(STDDIR)/biguinttest.mini $(STDDIR)/biguint.mini
 	$(CARGORUN) compile $(STDDIR)/biguinttest.mini -o $(STDDIR)/biguinttest.mexe
@@ -47,9 +47,6 @@ $(STDDIR)/sha256test.mexe: $(STDDIR)/sha256test.mini
 
 $(STDDIR)/rlptest.mexe: $(BUILTINMAOS) $(STDDIR)/rlptest.mini
 	$(CARGORUN) compile $(STDDIR)/rlptest.mini -o $(STDDIR)/rlptest.mexe
-
-$(STDDIR)/bls.mao: $(STDDIR)/bls.mini
-	$(CARGORUN) compile $(STDDIR)/bls.mini -c -o $(STDDIR)/bls.mao
 
 $(BUILTINDIR)/maptest.mexe: $(BUILTINMAOS) $(BUILTINDIR)/maptest.mini
 	$(CARGORUN) compile $(BUILTINDIR)/maptest.mini -o $(BUILTINDIR)/maptest.mexe

--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -7,8 +7,8 @@ use accounts::Account;
 use std::bytearray::ByteArray;
 use std::bytearray::MarshalledBytes;
 use std::stack::Stack;
-import type AccountStore;
-import type ByteStream;
+use accounts::AccountStore;
+use std::bytestream::ByteStream;
 
 use evmCallStack::evmCallStack_topFrame;
 use evmCallStack::evmCallStack_setAccount;
@@ -52,12 +52,7 @@ use std::bytestream::bytestream_bytesReadSoFar;
 use inbox::inbox_currentBlockNumber;
 use inbox::inbox_currentTimestamp;
 
-import func bytestream_new(ba: ByteArray) -> ByteStream;
-
-import func stack_pop(stack: Stack) -> option<(Stack, any)>;
-
-import impure func inbox_currentBlockNumber() -> uint;
-import impure func inbox_currentTimestamp() -> uint;
+use std::stack::stack_pop;
 
 use output::queueMessageForSend;
 
@@ -80,7 +75,7 @@ use std::bls::bls_marshalPublicKey;
 
 use decompression::parseAggregatorFunctionTable;
 
-import impure func pcTableForCode(code: ByteArray) -> option<Stack>;
+use codeSegment::pcTableForCode;
 
 
 public impure func arbsys_txcall() {

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -12,6 +12,7 @@ use std::bytestream::ByteStream;
 use std::bytearray::MarshalledBytes;
 use std::stack::Stack;
 use std::storageMap::StorageMap;
+use messages::TxRequestData;
 
 use errorHandler::errorHandler;
 
@@ -63,6 +64,7 @@ use std::stack::stack_push;
 use std::stack::stack_pop;
 use std::stack::stack_discardDeepestItems;
 
+use gasAccounting::GasUsage;
 use gasAccounting::gasAccounting_startTxCharges;
 use gasAccounting::gasAccounting_endTxCharges;
 use gasAccounting::gasAccounting_pauseTxCharges;
@@ -79,12 +81,6 @@ use output::sendQueuedMessages;
 
 use inbox::IncomingRequest;
 
-
-// This is declared identically in gasAccounting.mini
-type GasUsage = struct {
-    gasUsed: uint,
-    gasPriceWei: uint,
-}
 
 // This callframe is used to represent an EVM call in progress.
 // The callframe will have a full copy of the global AccountStore, but
@@ -157,19 +153,6 @@ public impure func evmCallStack_stackInfo() -> (uint, (address, address), (addre
     } else {
         return (0, (address(0), address(0)), (address(0), address(0)));
     }
-}
-
-type TxRequestData = struct {
-    maxGas: uint,
-    gasPrice: uint,
-    seqNum: option<uint>,
-    caller: address,
-    calleeAddr: address,
-    value: uint,
-    calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
-    incomingRequest: IncomingRequest,
 }
 
 public impure func initEvmCallStack(

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -16,6 +16,8 @@ use accounts::accountStore_set;
 use accounts::account_addToEthBalance;
 use accounts::account_deductFromEthBalance;
 
+use messages::TxRequestData;
+
 use std::bytearray::bytearray_new;
 use std::bytearray::bytearray_getByte;
 use std::bytearray::bytearray_get256;
@@ -229,20 +231,6 @@ impure func switchToChargingOS() -> uint {
         asm(~0,) { setgas };
         return gasRemaining;
     }
-}
-
-// TxRequestData is declared identically in message.mini and elsewhere.
-type TxRequestData = struct {
-    maxGas: uint,
-    gasPrice: uint,
-    seqNum: option<uint>,
-    caller: address,
-    calleeAddr: address,
-    value: uint,
-    calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
-    incomingRequest: IncomingRequest,
 }
 
 // The next section of code implements the congestion auction. For each request, the auction

--- a/arb_os/messageBatch.mini
+++ b/arb_os/messageBatch.mini
@@ -21,7 +21,7 @@ use std::bytearray::marshalledBytes_hash;
 
 use inbox::IncomingRequest;
 
-import func rlp_decodeUint(bs: ByteStream) -> option<(ByteStream, uint)>;
+use std::rlp::rlp_decodeUint;
 
 
 type MessageBatch = struct {

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -50,12 +50,8 @@ use codeSegment::translateEvmCodeSegment;
 
 use inbox::IncomingRequest;
 
+use gasAccounting::GasUsage;
 
-// This is declared identically in gasAccounting.mini
-type GasUsage = struct {
-    gasUsed: uint,
-    gasPriceWei: uint,
-}
 
 public impure func handleL1Request(
     msg: IncomingRequest

--- a/arb_os/output.mini
+++ b/arb_os/output.mini
@@ -23,12 +23,8 @@ use inbox::IncomingRequest;
 use inbox::inbox_currentBlockNumber;
 use inbox::inbox_currentTimestamp;
 
+use gasAccounting::GasUsage;
 
-// This is declared identically in gasAccounting.mini
-type GasUsage = struct {
-    gasUsed: uint,
-    gasPriceWei: uint,
-}
 
 // PerBlockReceiptData is different from OutputStatistics for now; might want to unify
 type PerBlockReceiptData = struct {

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -29,20 +29,7 @@ use std::keccak::keccak256;
 
 use inbox::IncomingRequest;
 
-
-// TxRequestData is declared identically in message.mini and elsewhere.
-type TxRequestData = struct {
-    maxGas: uint,
-    gasPrice: uint,
-    seqNum: option<uint>,
-    caller: address,
-    calleeAddr: address,
-    value: uint,
-    calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
-    incomingRequest: IncomingRequest,
-}
+use messages::TxRequestData;
 
 // A copy of this struct is defined in stdlib/rlp.mini.
 // The declaration there must remain consistent with the one here.

--- a/arb_os/tokens.mini
+++ b/arb_os/tokens.mini
@@ -20,19 +20,8 @@ use std::bytearray::bytearray_set256;
 
 use evmCallStack::initEvmCallStack;
 
-// This is duplicated from messages.mini
-type TxRequestData = struct {
-    maxGas: uint,
-    gasPrice: uint,
-    seqNum: option<uint>,
-    caller: address,
-    calleeAddr: address,
-    value: uint,
-    calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
-    incomingRequest: IncomingRequest,
-}
+use messages::TxRequestData;
+
 
 public impure func tokens_erc20deposit(
     tokenAddress: address,

--- a/builtin/arraytest.mini
+++ b/builtin/arraytest.mini
@@ -2,7 +2,8 @@
 // Copyright 2020, Offchain Labs, Inc. All rights reserved.
 //
 
-import func builtin_arrayOp(a: any, index: uint, closure: opClosure) -> (any, any);
+use core::array::array;
+use core::array::builtin_arrayOp;
 
 type opClosure = struct {
 	f: func(any, any) -> (any, any),
@@ -50,7 +51,7 @@ func tests() -> uint {
 	let a = newarray<uint>(17);
 	a = a with { [11] = 3 };
 	let result = builtin_arrayOp(
-		a,
+		unsafecast<array>(a),
 		11,
 		unsafecast<opClosure>(struct { f: addFunc, val: 4, })
 	);

--- a/builtin/kvstest.mini
+++ b/builtin/kvstest.mini
@@ -2,9 +2,13 @@
 // Copyright 2020, Offchain Labs, Inc. All rights reserved.
 //
 
-import func builtin_kvsDelete(kvs: any, key: any) -> any;
-import func builtin_kvsForall(kvs: any, cb: func(any, any, any) -> any, state: any) -> any;
-import func builtin_kvsSize(kvs: any) -> uint;
+use core::kvs::Kvs;
+use core::kvs::builtin_kvsNew;
+use core::kvs::builtin_kvsGet;
+use core::kvs::builtin_kvsSet;
+use core::kvs::builtin_kvsDelete;
+use core::kvs::builtin_kvsForall;
+use core::kvs::builtin_kvsSize;
 
 impure func main() {
 	asm(tests(),) { log };

--- a/stdlib/bytestream.mini
+++ b/stdlib/bytestream.mini
@@ -3,13 +3,13 @@
 //
 
 use std::bytearray::ByteArray;
+use std::bytearray::bytearray_new;
 use std::bytearray::bytearray_size;
 use std::bytearray::bytearray_getByte;
 use std::bytearray::bytearray_get64;
 use std::bytearray::bytearray_get256;
 use std::bytearray::bytearray_extract;
 
-import func bytearray_new(unused: uint) -> ByteArray;
 
 type ByteStream = struct {
     contents: ByteArray,

--- a/stdlib/keccak.mini
+++ b/stdlib/keccak.mini
@@ -10,9 +10,7 @@ use std::bytearray::bytearray_get64;
 use std::bytearray::bytearray_set64;
 use std::bytearray::bytearray_getByte;
 use std::bytearray::bytearray_setByte;
-
-import func bytearray_copy(src: ByteArray, srcOffset: uint, dest: ByteArray, destOffset: uint, nbytes: uint) -> ByteArray;
-
+use std::bytearray::bytearray_copy;
 
 
 public func keccak256(ba: ByteArray, offset: uint, nbytes: uint) -> bytes32 {

--- a/stdlib/priorityq.mini
+++ b/stdlib/priorityq.mini
@@ -107,7 +107,7 @@ public func priorityq_insert(pq: PriorityQ, item: any, priority: uint) -> Priori
     if (pq.size == pq.capacity) {
         let newCapacity = 8*pq.capacity;
         pq = pq with { capacity: newCapacity }
-                with { contents: array_resize(unsafecast<array>(pq.contents), newCapacity, null) };
+                with { contents: unsafecast<any>(array_resize(unsafecast<array>(pq.contents), newCapacity, null)) };
     }
     let index = pq.size;
     let newpq = pq with { size: index+1 }

--- a/stdlib/priorityq.mini
+++ b/stdlib/priorityq.mini
@@ -2,7 +2,9 @@
 // Copyright 2020, Offchain Labs, Inc. All rights reserved.
 //
 
-import func array_resize(a: []PqItem, newSize: uint, baseVal: any) -> []PqItem;
+use core::array::array;
+use core::array::array_resize;
+
 
 type PqItem = struct {
     priority: uint,

--- a/stdlib/priorityq.mini
+++ b/stdlib/priorityq.mini
@@ -107,7 +107,7 @@ public func priorityq_insert(pq: PriorityQ, item: any, priority: uint) -> Priori
     if (pq.size == pq.capacity) {
         let newCapacity = 8*pq.capacity;
         pq = pq with { capacity: newCapacity }
-                with { contents: unsafecast<any>(array_resize(unsafecast<array>(pq.contents), newCapacity, null)) };
+                with { contents: unsafecast<[]PqItem>(array_resize(unsafecast<array>(pq.contents), newCapacity, null)) };
     }
     let index = pq.size;
     let newpq = pq with { size: index+1 }

--- a/stdlib/priorityq.mini
+++ b/stdlib/priorityq.mini
@@ -107,7 +107,7 @@ public func priorityq_insert(pq: PriorityQ, item: any, priority: uint) -> Priori
     if (pq.size == pq.capacity) {
         let newCapacity = 8*pq.capacity;
         pq = pq with { capacity: newCapacity }
-                with { contents: array_resize(pq.contents, newCapacity, null) };
+                with { contents: array_resize(unsafecast<array>(pq.contents), newCapacity, null) };
     }
     let index = pq.size;
     let newpq = pq with { size: index+1 }

--- a/stdlib/rlp.mini
+++ b/stdlib/rlp.mini
@@ -6,7 +6,8 @@ use std::bytearray::ByteArray;
 use std::bytestream::ByteStream;
 use std::keccak::Hasher;
 
-import func builtin_arrayGetSafe(arr: []any, index: uint) -> option<any>;
+use core::array::array;
+use core::array::builtin_arrayGetSafe;
 
 use std::bytearray::bytearray_new;
 use std::bytearray::bytearray_size;
@@ -254,7 +255,7 @@ public func rlp_encodeList(
     let totalWritten = 0;
     let i = 0;
     while (i < numEncItems) {
-        let item = unsafecast<ByteArray>(builtin_arrayGetSafe(encodedItems, encItemsOffset+i)?);
+        let item = unsafecast<ByteArray>(builtin_arrayGetSafe(unsafecast<array>(encodedItems), encItemsOffset+i)?);
         totalSize = totalSize + bytearray_size(item);
         i = i+1;
     }


### PR DESCRIPTION
* Eliminate duplicate type declarations
* Replace obsolete `import` statements with equivalent `use` statements
* Remove obsolete recipes from Makefile