### PR TITLE
Type display

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -281,6 +281,73 @@ impl Type {
             Type::Option(_) => (Value::new_tuple(vec![Value::Int(Uint256::zero())]), true),
         }
     }
+
+    pub fn display(&self) -> String {
+        match self {
+            Type::Void => "void".to_string(),
+            Type::Uint => "uint".to_string(),
+            Type::Int => "int".to_string(),
+            Type::Bool => "bool".to_string(),
+            Type::Bytes32 => "bytes32".to_string(),
+            Type::EthAddress => "address".to_string(),
+            Type::Buffer => "buffer".to_string(),
+            Type::Tuple(subtypes) => {
+                let mut out = "(".to_string();
+                for s in subtypes {
+                    //This should be improved by removing the final trailing comma.
+                    out.push_str(&(s.display() + ", "));
+                }
+                out.push(')');
+                out
+            }
+            Type::Array(t) => format!("[]{}", t.display()),
+            Type::FixedArray(t, size) => format!("[{}]{}", size, t.display()),
+            Type::Struct(fields) => {
+                let mut out = "struct {\n".to_string();
+                for field in fields {
+                    //This should indent further when dealing with sub-structs
+                    out.push_str(&format!(
+                        "    {}: {},\n",
+                        field.name,
+                        field.tipe.display()
+                    ));
+                }
+                out.push('}');
+                out
+            }
+            Type::Nominal(path, id) => {
+                let mut out = String::new();
+                for path_item in path {
+                    out.push_str(&format!("{}::", path_item))
+                }
+                out.push_str(&format!("{}", id));
+                out
+            }
+            Type::Func(impure, args, ret) => {
+                let mut out = String::new();
+                if *impure {
+                    out.push_str("impure ");
+                }
+                out.push_str("func(");
+                for arg in args {
+                    out.push_str(&(arg.display() + ", "));
+                }
+                out.push(')');
+                if **ret != Type::Void {
+                    out.push_str(" -> ");
+                    out.push_str(&ret.display());
+                }
+                out
+            }
+            Type::Map(key, val) => {
+                format!("map<{},{}>", key.display(), val.display())
+            }
+            Type::Imported(id) => format!("imported({})", id),
+            Type::Any => "any".to_string(),
+            Type::Every => "every".to_string(),
+            Type::Option(t) => format!("option<{}>", t.display()),
+        }
+    }
 }
 
 ///Returns true if each type in tvec2 is a subtype of the type in tvec1 at the same index, and tvec1

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -306,11 +306,7 @@ impl Type {
                 let mut out = "struct {\n".to_string();
                 for field in fields {
                     //This should indent further when dealing with sub-structs
-                    out.push_str(&format!(
-                        "    {}: {},\n",
-                        field.name,
-                        field.tipe.display()
-                    ));
+                    out.push_str(&format!("    {}: {},\n", field.name, field.tipe.display()));
                 }
                 out.push('}');
                 out

--- a/src/compile/miniconstants.rs
+++ b/src/compile/miniconstants.rs
@@ -229,8 +229,8 @@ pub fn init_constant_table() -> HashMap<String, Uint256> {
         (
             "BLSSignatureDomainBase",
             // Keccak256 of "Arbitrum BLS signature domain"
-            "73a92f91d473214defd5ffa91d036007eb2e6487fffaa551835e988fb24aaa2b"
-        )
+            "73a92f91d473214defd5ffa91d036007eb2e6487fffaa551835e988fb24aaa2b",
+        ),
     ] {
         ret.insert(s.to_string(), Uint256::from_string_hex(u).unwrap());
     }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1656,19 +1656,11 @@ fn typecheck_expr(
                     type_tree,
                     scopes,
                 )?;
-                if tc_sub1.get_type() != Type::Bool {
+                if (tc_sub1.get_type(), tc_sub2.get_type()) != (Type::Bool, Type::Bool) {
                     return Err(new_type_error(
                         format!(
-                            "operands to logical and must be boolean, got {}",
-                            tc_sub1.get_type().display()
-                        ),
-                        loc,
-                    ));
-                }
-                if tc_sub2.get_type() != Type::Bool {
-                    return Err(new_type_error(
-                        format!(
-                            "operands to logical and must be boolean, got {}",
+                            "operands to logical and must be boolean, got \"{}\" and \"{}\"",
+                            tc_sub1.get_type().display(),
                             tc_sub2.get_type().display()
                         ),
                         loc,

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1622,20 +1622,12 @@ fn typecheck_expr(
                     type_tree,
                     scopes,
                 )?;
-                if tc_sub1.get_type() != Type::Bool {
+                if (tc_sub1.get_type(), tc_sub2.get_type()) != (Type::Bool, Type::Bool) {
                     return Err(new_type_error(
                         format!(
-                            "operands to logical or must be boolean, got {}",
-                            tc_sub1.get_type().display()
-                        ),
-                        loc,
-                    ));
-                }
-                if tc_sub2.get_type() != Type::Bool {
-                    return Err(new_type_error(
-                        format!(
-                            "operands to logical or must be boolean, got {}",
-                            tc_sub2.get_type().display()
+                            "operands to logical or must be boolean, got \"{}\" and \"{}\"",
+                            tc_sub1.get_type().display(),
+                            tc_sub2.get_type().display(),
                         ),
                         loc,
                     ));
@@ -1952,7 +1944,7 @@ fn typecheck_expr(
                         } else {
                             Err(new_type_error(
                                 format!(
-                                    "fixedarray index must be Uint, found \"{}\"",
+                                    "fixedarray index must be uint, found \"{}\"",
                                     tc_idx.get_type().display()
                                 ),
                                 loc,

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1340,7 +1340,10 @@ fn typecheck_statement<'a>(
                 Type::Option(t) => *t,
                 unexpected => {
                     return Err(new_type_error(
-                        format!("Expected option type got: {:?}", unexpected),
+                        format!(
+                            "Expected option type got: \"{}\"",
+                            unexpected.display()
+                        ),
                         debug_info.location,
                     ))
                 }

--- a/src/evm/bls.rs
+++ b/src/evm/bls.rs
@@ -2,10 +2,10 @@
  * Copyright 2020, Offchain Labs, Inc. All rights reserved
  */
 
-use crate::evm::test_contract_path;
-use crate::evm::abi::{builtin_contract_path, AbiForContract};
-use crate::run::{load_from_file, Machine, RuntimeEnvironment};
 use crate::compile::miniconstants::init_constant_table;
+use crate::evm::abi::{builtin_contract_path, AbiForContract};
+use crate::evm::test_contract_path;
+use crate::run::{load_from_file, Machine, RuntimeEnvironment};
 use crate::uint256::Uint256;
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;
@@ -164,28 +164,23 @@ pub fn _evm_test_bls_registry(log_to: Option<&Path>, debug: bool) {
     }
 }
 
-fn _to_32_bytes_be(bi: &BigUint) -> Vec<u8>{
+fn _to_32_bytes_be(bi: &BigUint) -> Vec<u8> {
     let bytes = bi.to_bytes_be();
     let len = bytes.len();
     if len > 32 {
         panic!(); // altenratively, retrun error cal like all 0 vector?
     } else if len < 32 {
         let mut out = vec![0u8; 32];
-        out[32-len..32].clone_from_slice(&bytes);
+        out[32 - len..32].clone_from_slice(&bytes);
         return out;
     }
     bytes
 }
 
-pub fn _hash_to_point(
-    domain: &Uint256,
-    msg: &[u8]
-    ) -> Option<G1> {
-
+pub fn _hash_to_point(domain: &Uint256, msg: &[u8]) -> Option<G1> {
     let (u0, u1) = _hash_to_field(domain, msg);
     if let Some((px_bi, py_bi)) = _map_to_g1(&u0) {
         if let Some((qx_bi, qy_bi)) = _map_to_g1(&u1) {
-
             let px = Fq::from_slice(&_to_32_bytes_be(&px_bi)).unwrap();
             let py = Fq::from_slice(&_to_32_bytes_be(&py_bi)).unwrap();
             let qx = Fq::from_slice(&_to_32_bytes_be(&qx_bi)).unwrap();
@@ -207,7 +202,7 @@ pub fn _hash_to_point(
             ret.x().to_big_endian(&mut out_buf_0).unwrap();
             let mut out_buf_1 = vec![0u8; 32];
             ret.y().to_big_endian(&mut out_buf_1).unwrap();
-            return Some(ret) 
+            return Some(ret);
         }
     }
     None
@@ -255,7 +250,11 @@ fn _map_to_g1(_x: &BigUint) -> Option<(BigUint, BigUint)> {
     a1 = (&a1 + &ToBigUint::to_biguint(&3).unwrap()).mod_floor(&field_order);
 
     if let Some(sqa1) = _sqrt(&a1) {
-        a1 = if (found_first_sqrt) { sqa1 } else { &field_order - sqa1 };
+        a1 = if (found_first_sqrt) {
+            sqa1
+        } else {
+            &field_order - sqa1
+        };
         return Some((x, a1));
     }
 
@@ -267,7 +266,11 @@ fn _map_to_g1(_x: &BigUint) -> Option<(BigUint, BigUint)> {
     a1 = (&a1 + &ToBigUint::to_biguint(&3).unwrap()).mod_floor(&field_order);
 
     if let Some(sqa1) = _sqrt(&a1) {
-        a1 = if (found_first_sqrt) { sqa1 } else { &field_order - sqa1 };
+        a1 = if (found_first_sqrt) {
+            sqa1
+        } else {
+            &field_order - sqa1
+        };
         return Some((x, a1));
     }
 
@@ -282,7 +285,11 @@ fn _map_to_g1(_x: &BigUint) -> Option<(BigUint, BigUint)> {
     a1 = (&a1 + &ToBigUint::to_biguint(&3).unwrap()).mod_floor(&field_order);
 
     if let Some(sqa1) = _sqrt(&a1) {
-        a1 = if (found_first_sqrt) { sqa1 } else { &field_order - sqa1 };
+        a1 = if (found_first_sqrt) {
+            sqa1
+        } else {
+            &field_order - sqa1
+        };
         Some((x, a1))
     } else {
         None
@@ -456,16 +463,13 @@ pub fn _generate_bls_key_pair() -> (_BLSPublicKey, _BLSPrivateKey) {
 fn _domain_for_sender(sender: Uint256) -> Uint256 {
     Uint256::avm_hash2(
         init_constant_table().get("BLSSignatureDomainBase").unwrap(),
-        &sender
+        &sender,
     )
 }
 
 impl _BLSPrivateKey {
     pub fn _sign_message(&self, sender_address: Uint256, message: &[u8]) -> _BLSSignature {
-        let h = _hash_to_point(
-            &_domain_for_sender(sender_address),
-            message
-        );
+        let h = _hash_to_point(&_domain_for_sender(sender_address), message);
         // ignores error that should never arise that would return None for h. Handle and Return Option<BLSSignature> instead?
         let sigma = h.unwrap() * self.s;
         _BLSSignature {
@@ -582,20 +586,21 @@ pub fn _evm_test_bls_signed_batch(log_to: Option<&Path>, debug: bool) -> Result<
     let b4 = bob_public_key._to_four_uints();
     bob_arb_bls._register(&mut machine, b4.0, b4.1, b4.2, b4.3)?;
 
-    let (alice_compressed_tx, alice_hash_to_sign) = machine.runtime_env._make_compressed_tx_for_bls(
-        &alice_addr,
-        Uint256::zero(),
-        Uint256::from_u64(100000000),
-        add_contract.address.clone(),
-        Uint256::zero(),
-        &add_contract._generate_calldata_for_function(
-            "add",
-            &[
-                ethabi::Token::Uint(Uint256::one().to_u256()),
-                ethabi::Token::Uint(Uint256::one().to_u256()),
-            ],
-        )?,
-    );
+    let (alice_compressed_tx, alice_hash_to_sign) =
+        machine.runtime_env._make_compressed_tx_for_bls(
+            &alice_addr,
+            Uint256::zero(),
+            Uint256::from_u64(100000000),
+            add_contract.address.clone(),
+            Uint256::zero(),
+            &add_contract._generate_calldata_for_function(
+                "add",
+                &[
+                    ethabi::Token::Uint(Uint256::one().to_u256()),
+                    ethabi::Token::Uint(Uint256::one().to_u256()),
+                ],
+            )?,
+        );
     let (bob_compressed_tx, bob_hash_to_sign) = machine.runtime_env._make_compressed_tx_for_bls(
         &bob_addr,
         Uint256::zero(),
@@ -639,8 +644,14 @@ pub fn _evm_test_bls_signed_batch(log_to: Option<&Path>, debug: bool) -> Result<
     assert_eq!(logs.len(), num_logs_before + 2);
     assert!(logs[logs.len() - 2].succeeded());
     assert!(logs[logs.len() - 1].succeeded());
-    assert_eq!(Uint256::from_bytes(&logs[logs.len()-2].get_return_data()), Uint256::from_u64(2));
-    assert_eq!(Uint256::from_bytes(&logs[logs.len()-1].get_return_data()), Uint256::from_u64(27+96));
+    assert_eq!(
+        Uint256::from_bytes(&logs[logs.len() - 2].get_return_data()),
+        Uint256::from_u64(2)
+    );
+    assert_eq!(
+        Uint256::from_bytes(&logs[logs.len() - 1].get_return_data()),
+        Uint256::from_u64(27 + 96)
+    );
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();


### PR DESCRIPTION
This adds a method `display` to `Type` that returns a string representing how that type would appear in mini code.  There are a few formatting limitations:

1. A trailing comma followed by a space always appears where it is possible.
2. Struct fields are always indented by four spaces, including sub-structs.
3. Named types are identified by path and ID.

For example the type `struct { x: (uint, option<[4]int>)}` will return:
```
struct {
    x: (uint, option<[4]int>, ),
}
```

This method has been used to include type information with various error messages, and replaces debug formatting for others.  This method is not implemented as a `Display` impl, as to resolve named types we will need to add an additional argument.
