### PR TITLE
Fix develop

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -366,6 +366,7 @@ public impure func initEvmCallStackForConstructor(
                 callvalue: request.value,
                 returnInfo: None<ReturnInfo>,
                 memory: bytearray_new(0),
+                storageDelta: int(0),
                 revertOnStorageWrite: false,
                 evmLogs: evmlogs_empty(),
                 selfDestructQueue: queue_new(),


### PR DESCRIPTION
Ed's integration fix is necessary to have correct execution in both next and develop, so it should be available in both.