### PR TITLE
Debug print location

### DIFF
--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -15,7 +15,7 @@ use miniconstants::init_constant_table;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Read};
@@ -666,14 +666,9 @@ pub struct CompileError {
     pub location: Option<Location>,
 }
 
-impl std::fmt::Display for CompileError {
+impl Display for CompileError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        if let Some(loc) = self.location {
-            write!(f, "{},\n{}", self.description, loc)?;
-        } else {
-            write!(f, "{},\n No location", self.description)?;
-        }
-        Ok(())
+        write!(f, "{}", self.description)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,19 +4,21 @@
 
 #![allow(unused_parens)]
 
+use clap::Clap;
 use compile::{compile_from_file, CompileError};
 use contracttemplates::generate_contract_template_file_or_die;
 use link::{link, postlink_compile};
 use mavm::Value;
-use run::{profile_gen_from_file, replay_from_testlog_file, run_from_file, RuntimeEnvironment};
+use pos::try_display_location;
+use run::{
+    profile_gen_from_file, replay_from_testlog_file, run_from_file, ProfilerMode,
+    RuntimeEnvironment,
+};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io;
 use std::path::Path;
-
-use crate::run::ProfilerMode;
-use crate::uint256::Uint256;
-use clap::Clap;
+use uint256::Uint256;
 
 #[cfg(test)]
 mod buffertests;
@@ -132,7 +134,11 @@ fn main() -> Result<(), CompileError> {
                         });
                     }
                     Err(e) => {
-                        println!("Compilation error: {:?}\nIn file: {}", e, filename);
+                        println!(
+                            "Compilation error: {}\n{}",
+                            e,
+                            try_display_location(e.location, file_name_chart)
+                        );
                         return Err(e);
                     }
                 }
@@ -150,14 +156,9 @@ fn main() -> Result<(), CompileError> {
                         }
                         Err(e) => {
                             println!(
-                                "Compilation error: {}\nIn file: {}",
+                                "Compilation error: {}\n{}",
                                 e,
-                                e.location
-                                    .map(|loc| file_name_chart
-                                        .get(&loc.file_id)
-                                        .unwrap_or(&loc.file_id.to_string())
-                                        .clone())
-                                    .unwrap_or("Unknown".to_string())
+                                try_display_location(e.location, file_name_chart)
                             );
                             return Err(e);
                         }
@@ -180,14 +181,9 @@ fn main() -> Result<(), CompileError> {
                             }
                             Err(e) => {
                                 println!(
-                                    "Linking error: {}\nIn file: {}",
+                                    "Linking error: {}\n{}",
                                     e,
-                                    e.location
-                                        .map(|loc| file_name_chart
-                                            .get(&loc.file_id)
-                                            .unwrap_or(&loc.file_id.to_string())
-                                            .clone())
-                                        .unwrap_or("Unknown".to_string())
+                                    try_display_location(e.location, file_name_chart)
                                 );
                                 return Err(e);
                             }
@@ -195,14 +191,9 @@ fn main() -> Result<(), CompileError> {
                     }
                     Err(e) => {
                         println!(
-                            "Linking error: {}\nIn file: {}",
+                            "Linking error: {}\n{}",
                             e,
-                            e.location
-                                .map(|loc| file_name_chart
-                                    .get(&loc.file_id)
-                                    .unwrap_or(&loc.file_id.to_string())
-                                    .clone())
-                                .unwrap_or("Unknown".to_string())
+                            try_display_location(e.location, file_name_chart)
                         );
                         return Err(e);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<(), CompileError> {
                         println!(
                             "Compilation error: {}\n{}",
                             e,
-                            try_display_location(e.location, file_name_chart)
+                            try_display_location(e.location, &file_name_chart)
                         );
                         return Err(e);
                     }
@@ -158,7 +158,7 @@ fn main() -> Result<(), CompileError> {
                             println!(
                                 "Compilation error: {}\n{}",
                                 e,
-                                try_display_location(e.location, file_name_chart)
+                                try_display_location(e.location, &file_name_chart)
                             );
                             return Err(e);
                         }
@@ -183,7 +183,7 @@ fn main() -> Result<(), CompileError> {
                                 println!(
                                     "Linking error: {}\n{}",
                                     e,
-                                    try_display_location(e.location, file_name_chart)
+                                    try_display_location(e.location, &file_name_chart)
                                 );
                                 return Err(e);
                             }
@@ -193,7 +193,7 @@ fn main() -> Result<(), CompileError> {
                         println!(
                             "Linking error: {}\n{}",
                             e,
-                            try_display_location(e.location, file_name_chart)
+                            try_display_location(e.location, &file_name_chart)
                         );
                         return Err(e);
                     }

--- a/src/pos.rs
+++ b/src/pos.rs
@@ -135,7 +135,7 @@ impl fmt::Display for Location {
 }
 
 impl Location {
-    pub fn display_with_file(&self, file_name_chart: BTreeMap<u64, String>) -> String {
+    pub fn display_with_file(&self, file_name_chart: &BTreeMap<u64, String>) -> String {
         format!(
             "{}\nIn file: {}",
             self,
@@ -148,7 +148,7 @@ impl Location {
 
 pub fn try_display_location(
     location: Option<Location>,
-    file_name_chart: BTreeMap<u64, String>,
+    file_name_chart: &BTreeMap<u64, String>,
 ) -> String {
     location
         .map(|loc| loc.display_with_file(file_name_chart))

--- a/src/pos.rs
+++ b/src/pos.rs
@@ -7,6 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::cmp::{self, Ordering};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
@@ -131,6 +132,27 @@ impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Line: {}, Column: {}", self.line, self.column)
     }
+}
+
+impl Location {
+    pub fn display_with_file(&self, file_name_chart: BTreeMap<u64, String>) -> String {
+        format!(
+            "{}\nIn file: {}",
+            self,
+            file_name_chart
+                .get(&self.file_id)
+                .unwrap_or(&self.file_id.to_string())
+        )
+    }
+}
+
+pub fn try_display_location(
+    location: Option<Location>,
+    file_name_chart: BTreeMap<u64, String>,
+) -> String {
+    location
+        .map(|loc| loc.display_with_file(file_name_chart))
+        .unwrap_or("No location".to_string())
 }
 
 /// An expansion identifier tracks whether a span originated from a macro expansion or not.

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -8,7 +8,7 @@ use super::runtime_env::RuntimeEnvironment;
 use crate::compile::{CompileError, DebugInfo};
 use crate::link::LinkedProgram;
 use crate::mavm::{AVMOpcode, Buffer, CodePt, Instruction, Opcode, Value};
-use crate::pos::Location;
+use crate::pos::{try_display_location, Location};
 use crate::run::ripemd160port;
 use crate::uint256::Uint256;
 use clap::Clap;
@@ -1941,6 +1941,7 @@ impl Machine {
 					Opcode::AVMOpcode(AVMOpcode::DebugPrint) => {
 						let r1 = self.stack.pop(&self.state)?;
                         println!("debugprint: {}", r1);
+                        println!("{}", try_display_location(insn.debug_info.location, &self.file_name_chart));
 						self.incr_pc();
 						Ok(true)
 					}

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1941,7 +1941,7 @@ impl Machine {
 					Opcode::AVMOpcode(AVMOpcode::DebugPrint) => {
 						let r1 = self.stack.pop(&self.state)?;
                         println!("debugprint: {}", r1);
-                        println!("{}", try_display_location(insn.debug_info.location, &self.file_name_chart));
+                        println!("{}\n{}", try_display_location(insn.debug_info.location, &self.file_name_chart), self.arb_gas_remaining);
 						self.incr_pc();
 						Ok(true)
 					}


### PR DESCRIPTION
This refactors the way that location information is printed by the compiler and prints the location information of the instruction when a debugprint occurs.