### PR TITLE
Change send opcode to take [size, buffer] arguments

### DIFF
--- a/arb_os/output.mini
+++ b/arb_os/output.mini
@@ -240,7 +240,7 @@ impure func emitBlockSummaryLog(blockNum: uint, timestamp: uint, prevBlockNum: u
         gasAccounting_summaryToPublish(),
         prevBlockNum
     ),) { log };
-    asm(merkleTreeBuilder_rootHash(merkleOfSends),) { send };
+    asm(32, setbuffer256(newbuffer(), 0, uint(merkleTreeBuilder_rootHash(merkleOfSends)))) { send };
     merkleOfSends = merkleTreeBuilder_new();
 }
 
@@ -281,6 +281,5 @@ func workaroundForCompilerBug() { }  // This is needed to work around a compiler
 impure func sendPackagedMessage(msg: any) {
     outputStats_addSend();
     merkleOfSends = merkleTreeBuilder_add(merkleOfSends, msg);
-    // asm(msg,) { send };
     asm((const::LogType_send, msg),) { log };
 }

--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -456,6 +456,14 @@ impl Buffer {
         }
     }
 
+    pub fn as_bytes(&self, nbytes: usize) -> Vec<u8> {
+        let mut ret = vec![];
+        for i in 0..nbytes {
+            ret.push(self.read_byte(i));
+        }
+        ret
+    }
+
     pub fn avm_hash(&self) -> Uint256 {
         Uint256::avm_hash2(&Uint256::from_u64(123), &self.hash().hash)
     }

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1872,8 +1872,9 @@ impl Machine {
 						Ok(true)
 					}
 					Opcode::AVMOpcode(AVMOpcode::Send) => {
-                        let val = self.stack.pop(&self.state)?;
-                        self.runtime_env.push_send(val);
+                        let size = self.stack.pop_uint(&self.state)?;
+                        let buf = self.stack.pop_buffer(&self.state)?;
+                        self.runtime_env.push_send(size, buf);
                         self.incr_pc();
                         Ok(true)
 					}

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -2,7 +2,7 @@
  * Copyright 2020, Offchain Labs, Inc. All rights reserved.
  */
 
-use crate::mavm::Value;
+use crate::mavm::{Value, Buffer};
 use crate::run::{load_from_file, ProfilerMode};
 use crate::uint256::Uint256;
 use ethers_core::rand::rngs::StdRng;
@@ -23,7 +23,7 @@ pub struct RuntimeEnvironment {
     pub current_block_num: Uint256,
     pub current_timestamp: Uint256,
     pub logs: Vec<Value>,
-    pub sends: Vec<Value>,
+    pub sends: Vec<Vec<u8>>,
     pub next_inbox_seq_num: Uint256,
     pub caller_seq_nums: HashMap<Uint256, Uint256>,
     next_id: Uint256, // used to assign unique (but artificial) txids to messages
@@ -590,9 +590,10 @@ impl RuntimeEnvironment {
             .collect()
     }
 
-    pub fn push_send(&mut self, send_item: Value) {
-        self.sends.push(send_item.clone());
-        self.recorder.add_send(send_item);
+    pub fn push_send(&mut self, size: Uint256, buf: Buffer) {
+        let send_bytes = buf.as_bytes(size.to_usize().unwrap());
+        self.sends.push(send_bytes.clone());
+        self.recorder.add_send(send_bytes);
     }
 
     pub fn get_all_sends(&self) -> Vec<Value> {
@@ -1161,7 +1162,7 @@ pub struct RtEnvRecorder {
     format_version: u64,
     inbox: Vec<Value>,
     logs: Vec<Value>,
-    sends: Vec<Value>,
+    sends: Vec<Vec<u8>>,
 }
 
 impl RtEnvRecorder {
@@ -1182,7 +1183,7 @@ impl RtEnvRecorder {
         self.logs.push(log_item);
     }
 
-    fn add_send(&mut self, send_item: Value) {
+    fn add_send(&mut self, send_item: Vec<u8>) {
         self.sends.push(send_item);
     }
 
@@ -1244,7 +1245,7 @@ impl RtEnvRecorder {
             return false;
         }
         if !(self.sends == machine.runtime_env.recorder.sends) {
-            print_output_differences(
+            print_output_differences_bytes(
                 "send",
                 machine.runtime_env.recorder.sends,
                 self.sends.clone(),
@@ -1325,6 +1326,27 @@ fn print_output_differences(kind: &str, seen: Vec<Value>, expected: Vec<Value>) 
                 println!("{} {} mismatch:", kind, i);
                 println!("expected: {}", expected[i]);
                 println!("seen: {}", seen[i]);
+                return;
+            }
+        }
+    }
+}
+
+fn print_output_differences_bytes(kind: &str, seen: Vec<Vec<u8>>, expected: Vec<Vec<u8>>) {
+    if seen.len() != expected.len() {
+        println!(
+            "{} mismatch: expected {}, got {}",
+            kind,
+            expected.len(),
+            seen.len()
+        );
+        return;
+    } else {
+        for i in 0..(seen.len()) {
+            if !(seen[i] == expected[i]) {
+                println!("{} {} mismatch:", kind, i);
+                println!("expected: {:?}", expected[i]);
+                println!("seen: {:?}", seen[i]);
                 return;
             }
         }


### PR DESCRIPTION
* Change the `send` opcode to take two stack arguments [size, buffer] and output a byte-string (like a Solidity `bytes` object).
* Update Rust client and tests to account for this change
* Change ArbOS to account for this change.  Instead of sending a single `bytes32` object, this now sends a byte-string of size 32.

The Rust VM currently does not check that the `size` argument is within bounds.  (It will always be within bounds for ArbOS, because all ArbOS sends will be of size 32.)