### PR TITLE
Add type byte to beginning of AVM send contents

### DIFF
--- a/arb_os/output.mini
+++ b/arb_os/output.mini
@@ -293,14 +293,18 @@ impure func outbox_send() {
     let (tree, rootHash) = merkleTreeBuilder_finish(globalOutbox.batch);
     asm((const::LogType_sendMerkleTree, globalOutbox.batchNumber, globalOutbox.numInBatch, tree),) { log };
     asm(
-        96,
+        97,
         setbuffer256(
             setbuffer256(
-                setbuffer256(newbuffer(), 0, globalOutbox.batchNumber),
-                32,
+                setbuffer256(
+                    setbuffer8(newbuffer(), 0, const::AVMSendType_batch),
+                    1,
+                    globalOutbox.batchNumber
+                ),
+                33,
                 globalOutbox.numInBatch
             ),
-            64,
+            65,
             uint(rootHash)
 
         )

--- a/src/compile/miniconstants.rs
+++ b/src/compile/miniconstants.rs
@@ -187,6 +187,8 @@ pub fn init_constant_table() -> HashMap<String, Uint256> {
         ("SendType_withdrawETH", 0),
         ("SendType_sendTxToL1", 3),
         ("SendType_buddyContractResult", 5),
+        // AVM send types
+        ("AVMSendType_batch", 0),
         // chain initialization options
         ("InitOption_setSecondsPerBlock", 1),
         ("InitOption_setChargingParams", 2),


### PR DESCRIPTION
Add a send-type byte to the beginning of the data emitted on an AVM send.  Type 0 is a standard outbox batch.