### PR TITLE
If let expressions

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -660,6 +660,7 @@ pub enum ExprKind {
     Asm(Type, Vec<Instruction>, Vec<Expr>),
     Try(Box<Expr>),
     If(Box<Expr>, CodeBlock, Option<CodeBlock>),
+    IfLet(StringId, Box<Expr>, CodeBlock, Option<CodeBlock>),
     NewBuffer,
 }
 

--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -2177,6 +2177,7 @@ fn mavm_codegen_expr<'a>(
             code.push(Instruction::from_opcode(Opcode::Label(end_label), debug));
             Ok((lg, code, max(cond_locals, max(block_locals, else_locals))))
         }
+        TypeCheckedExprKind::IfLet(_, _, _, _, _) => unimplemented!(),
     }
 }
 

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -643,7 +643,8 @@ impl AbstractSyntaxTree for TypeCheckedExpr {
                 TypeCheckedNode::Expression(exp2),
                 TypeCheckedNode::Expression(exp3),
             ],
-            TypeCheckedExprKind::If(cond, block, else_block, _) => cond
+            TypeCheckedExprKind::If(cond, block, else_block, _)
+            | TypeCheckedExprKind::IfLet(_, cond, block, else_block, _) => cond
                 .child_nodes()
                 .into_iter()
                 .chain(block.child_nodes().into_iter())
@@ -654,7 +655,6 @@ impl AbstractSyntaxTree for TypeCheckedExpr {
                         .flatten(),
                 )
                 .collect(),
-            TypeCheckedExprKind::IfLet(_, _, _, _, _) => unimplemented!(),
         }
     }
 }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -568,7 +568,8 @@ impl MiniProperties for TypeCheckedExpr {
                 instrs.iter().all(|inst| inst.is_pure()) && args.iter().all(|expr| expr.is_pure())
             }
             TypeCheckedExprKind::Try(expr, _) => expr.is_pure(),
-            TypeCheckedExprKind::If(cond, block, else_block, _) => {
+            TypeCheckedExprKind::If(cond, block, else_block, _)
+            | TypeCheckedExprKind::IfLet(_, cond, block, else_block, _) => {
                 cond.is_pure()
                     && block.is_pure()
                     && if let Some(block) = else_block {
@@ -577,7 +578,6 @@ impl MiniProperties for TypeCheckedExpr {
                         true
                     }
             }
-            TypeCheckedExprKind::IfLet(_, _, _, _, _) => unimplemented!(),
         }
     }
 }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -2284,6 +2284,7 @@ fn typecheck_expr(
                     ))
                 }
             }
+            ExprKind::IfLet(_, _, _, _) => unimplemented!(),
         }?,
         debug_info,
     })

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -247,12 +247,14 @@ Expr11: Expr = {
 	<lno: @L> <e:Expr11> "." <i:Ident> => Expr { kind: ExprKind::DotRef(Box::new(e), stringtable.name_from_id(i).to_string()), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr { kind: ExprKind::TupleRef(Box::new(e), u), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	<lno: @L> "xif" <cond: Expr> <cb: CodeBlockNew> <el: ElseIf?> => Expr { kind: ExprKind::If(Box::new(cond), cb, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
+	<lno: @L> "xif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlockNew> <el: ElseIf?> => unimplemented!(),
 	Expr12,
 }
 
 ElseIf: CodeBlock = {
     ("else" <CodeBlockNew>) => <>,
     <lno: @L> "elseif" <cond: Expr> <cb: CodeBlockNew> <el: ElseIf?> => CodeBlock::new(vec![], Some(Box::new(Expr { kind: ExprKind::If(Box::new(cond), cb, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))}))),
+    <lno: @L> "elseif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlock> <e: ("else" <CodeBlock>)?> => unimplemented!(),
 }
 
 Expr12: Expr = {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -247,14 +247,15 @@ Expr11: Expr = {
 	<lno: @L> <e:Expr11> "." <i:Ident> => Expr { kind: ExprKind::DotRef(Box::new(e), stringtable.name_from_id(i).to_string()), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	<lno: @L> <e:Expr11> "." <u:UnsignedInteger> => Expr { kind: ExprKind::TupleRef(Box::new(e), u), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	<lno: @L> "xif" <cond: Expr> <cb: CodeBlockNew> <el: ElseIf?> => Expr { kind: ExprKind::If(Box::new(cond), cb, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
-	<lno: @L> "xif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlockNew> <el: ElseIf?> => unimplemented!(),
+	<lno: @L> "xif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlockNew> <el: ElseIf?> => Expr { kind: ExprKind::IfLet(l, Box::new(r), t, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))},
 	Expr12,
 }
 
 ElseIf: CodeBlock = {
     ("else" <CodeBlockNew>) => <>,
     <lno: @L> "elseif" <cond: Expr> <cb: CodeBlockNew> <el: ElseIf?> => CodeBlock::new(vec![], Some(Box::new(Expr { kind: ExprKind::If(Box::new(cond), cb, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))}))),
-    <lno: @L> "elseif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlock> <e: ("else" <CodeBlock>)?> => unimplemented!(),
+    <lno: @L> "elseif" "let" "Some(" <l: Ident> ")" "=" <r:Expr> <t: CodeBlockNew> <el: ElseIf?> => CodeBlock::new(vec![], Some(Box::new(
+                                Expr { kind: ExprKind::IfLet(l, Box::new(r), t, el), debug_info: DebugInfo::from(file_info.location(BytePos::from(lno), filename))}))),
 }
 
 Expr12: Expr = {


### PR DESCRIPTION
This adds if let expressions to the language, and allows both if let and if expressions to be chained using elseif, including mixtures in the same chain.

This will allow for various code simplifications once all terminal `if`-`if let` statements are replaced by `return` statements using `if`-`if let` expressions