### PR TITLE
Fix number of locals in codegen of return expression of CodeBlock

### DIFF
--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -222,7 +222,7 @@ fn mavm_codegen_code_block<'a>(
         let (lg, code, prepushed_vals_expr) = mavm_codegen_expr(
             ret_expr,
             code,
-            num_locals,
+            nl,
             &new_locals,
             lab_gen,
             string_table,


### PR DESCRIPTION
Fixes bug in title, makes failing test pass.