### PR TITLE
Don't advance the inbox queue unless we're consuming a message

### DIFF
--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -154,8 +154,6 @@ public impure func inbox_get() -> IncomingRequest {
 
         let (updatedQ, rawMsg,) = incomingRequestQueue_getOrDie(globalInbox.queue);
 
-        globalInbox = globalInbox with { queue: updatedQ };
-
         let ebMsg = unsafecast<IncomingRequest>(rawMsg);
         if (ebMsg.blockNumber > globalInbox.blockNum) {
             if ((globalInbox.sequencer != None<SequencerState>) && globalInbox.seenMsgAtThisBlockNum) {
@@ -178,6 +176,8 @@ public impure func inbox_get() -> IncomingRequest {
                 };
             }
         }
+
+        globalInbox = globalInbox with { queue: updatedQ };
 
         if (ebMsg.kind == const::L1MessageType_chainInit) {
             chainParams_gotParamsMessage(ebMsg.sender, ebMsg.msgData);

--- a/contracts/test/package.json
+++ b/contracts/test/package.json
@@ -6,6 +6,6 @@
   "license": "Apache-2.0",
   "private": true,
   "devDependencies": {
-    "truffle": "^5.0.31",
+    "truffle": "^5.0.31"
   }
 }


### PR DESCRIPTION
The previous code sometimes advanced the inbox queue (discarding the message at its head), in a case where that message wouldn't be consumed.  This PR moves the code that advances the queue to a place where we know the head message will definitely be consumed.

Fixes #343.