### PR TITLE
Restrict non eip 155 signatures

### DIFF
--- a/arb_os/decompression.mini
+++ b/arb_os/decompression.mini
@@ -424,8 +424,7 @@ impure func decompressTx(
             calleeAddr: toAddr,
             value: value,
             calldata: calldata,
-            nonMutating: false,
-            isConstructor: (toAddr == address(0)),
+            flags: xif (toAddr == address(0)) { const::TxReqDataFlag_isConstructor } else { 0 },
             incomingRequest: unsafecast<IncomingRequest>(0),  // caller will fill this in
         }
     ));

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -323,7 +323,9 @@ public impure func initEvmCallStackForConstructor(
     // The constructor will run, and (if it succeeds) it will return code, which will become the new
     //      code for this new account.
 
-    globalCurrentTxRequest = request with { isConstructor: true };
+    globalCurrentTxRequest = request with {
+        flags: request.flags | const::TxReqDataFlag_isConstructor
+    };
 
     // Create an accountStore with the caller's sequence number incremented; will decide later whether to commit it
     let acctStore = getGlobalAccountStore();
@@ -610,7 +612,7 @@ public impure func evmCallStack_returnFromCall(
         // top-level call completed; will need to return to external caller
         if (success) {
             let gasUsage = gasAccounting_endTxCharges(topFrame.storageDelta - int(storageReclaimedForSDQ(topFrame)))?;
-            if (globalCurrentTxRequest.isConstructor) {
+            if ((globalCurrentTxRequest.flags & const::TxReqDataFlag_isConstructor) != 0) {
                 // Constructor call was successful, so finish setting up the account.
                 // The constructor's returndata is EVM code for the contract.
                 // Compile that EVM code into AVM, and substitute that in as the code for the contract.
@@ -707,7 +709,7 @@ public impure func evmCallStack_returnFromCall(
                     }
                 }
             } else {
-                if (! globalCurrentTxRequest.nonMutating) {
+                if ((globalCurrentTxRequest.flags & const::TxReqDataFlag_nonMutating) == 0) {
                     // It was a successful tx (not a non-mutating call).
                     // We'll commit the results of the tx
 

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -451,20 +451,6 @@ impure func payOutFundsToValidators() {  // this should only be called when not 
     }
 }
 
-// TxRequestData is declared identically in message.mini and elsewhere.
-type TxRequestData = struct {
-    maxGas: uint,
-    gasPrice: uint,
-    seqNum: option<uint>,
-    caller: address,
-    calleeAddr: address,
-    value: uint,
-    calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
-    incomingRequest: IncomingRequest,
-}
-
 // getNextRequestFromCongestionAuction implements the congestion auction. For each request, the auction
 //     determines (a) whether to approve the request for execution, and (b) what gas price the request will pay.
 // This uses a "pull" interface: the main run loop calls this to get the next request.

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -628,8 +628,8 @@ impure func translateUnsignedTx(request: IncomingRequest) -> option<TxRequestDat
             calleeAddr: address(destAddrAsUint),
             value: value,
             calldata: calldata,
-            nonMutating: (subtype == const::L2MessageType_nonmutatingCall),
-            isConstructor: (destAddrAsUint == 0),
+            flags: (xif (subtype == const::L2MessageType_nonmutatingCall) { const::TxReqDataFlag_nonMutating } else { 0 })
+                 | (xif (destAddrAsUint == 0) { const::TxReqDataFlag_isConstructor } else { 0 }),
             incomingRequest: request
         }
     );
@@ -658,8 +658,7 @@ func translateBuddyDeployTx(request: IncomingRequest) -> option<TxRequestData> {
             calleeAddr: address(0),
             value: value,
             calldata: calldata,
-            nonMutating: false,
-            isConstructor: true,
+            flags: const::TxReqDataFlag_isConstructor,
             incomingRequest: request
         }
     );

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -127,8 +127,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
-    nonMutating: bool,
-    isConstructor: bool,
+    flags: uint,
     incomingRequest: IncomingRequest,
 }
 
@@ -154,7 +153,7 @@ public impure func handleL2Request(
 
     if (request.calleeAddr == address(0)) {
         // this is a constructor call
-        if (request.nonMutating) {
+        if ( (request.flags & const::TxReqDataFlag_nonMutating) != 0) {
             // revert error (tried to call constructor in a non-mutating call)
             emitTxReceipt(
                 request.incomingRequest,
@@ -197,10 +196,11 @@ public impure func handleL2Request(
         }
     } else {
         // this is a non-constructor call
-        let callKind = const::EVMCallType_call;
-        if (request.nonMutating) {
-            callKind = const::EVMCallType_staticcall;
-        }
+        let callKind = xif( (request.flags & const::TxReqDataFlag_nonMutating) != 0) {
+            const::EVMCallType_staticcall
+        } else {
+            const::EVMCallType_call
+        };
 
         initEvmCallStack(callKind, request, None<ByteArray>);  // should never return
     }

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -68,8 +68,7 @@ public impure func translateSignedTx(req: IncomingRequest) -> option<TxRequestDa
             calleeAddr: signedTx.to,
             value: signedTx.value,
             calldata: signedTx.data,
-            nonMutating: false,
-            isConstructor: (signedTx.to == address(0)),
+            flags: xif (signedTx.to == address(0)) { const::TxReqDataFlag_isConstructor } else { 0 },
             incomingRequest: req with {
                 sender: signer
             } with {

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -81,6 +81,12 @@ public impure func translateSignedTx(req: IncomingRequest) -> option<TxRequestDa
 public impure func recoverSigner(tx: SignedTx) -> option<address> {
     let rlpHashForSig = bytes32(0);
     if ( (tx.v == 27) || (tx.v == 28) ) {
+        // This is a non-EIP-155 signature. We limit transactions signed this way, to protect against replay of
+        // old messages from the Ethereum main chain. Unless the transaction looks like a keyless deploy with zero
+        // callvalue, we reject the signature.
+        if ( (tx.seqNum != 0) || (tx.to != address(0)) || (tx.value != 0) ) {
+            return None;
+        }
         rlpHashForSig = rlp_encodeAndHashMessageInfoForSignature(tx, None<uint>);  // non-EIP155 signature
     } else {
         rlpHashForSig = rlp_encodeAndHashMessageInfoForSignature(tx, Some(chainParams_chainId()));  // EIP155 signature

--- a/src/compile/miniconstants.rs
+++ b/src/compile/miniconstants.rs
@@ -202,6 +202,9 @@ pub fn init_constant_table() -> HashMap<String, Uint256> {
         ("NetFee_defaultRate2Denom", 10000),
         ("NetFee_maxRate2Num", 1),
         ("NetFee_maxRate2Denom", 1000),
+        // TxRequestData flags
+        ("TxReqDataFlag_nonMutating", 1),
+        ("TxReqDataFlag_isConstructor", 2),
         // sequencer constants
         ("Sequencer_maxDelayBlocks", 32768),   // 128*256
         ("Sequencer_maxDelaySeconds", 983040), // 30*Sequencer_maxDelayBlocks

--- a/src/compile/miniconstants.rs
+++ b/src/compile/miniconstants.rs
@@ -205,6 +205,7 @@ pub fn init_constant_table() -> HashMap<String, Uint256> {
         // TxRequestData flags
         ("TxReqDataFlag_nonMutating", 1),
         ("TxReqDataFlag_isConstructor", 2),
+        ("TxReqDataFlag_nonEIP155Sig", 4),
         // sequencer constants
         ("Sequencer_maxDelayBlocks", 32768),   // 128*256
         ("Sequencer_maxDelaySeconds", 983040), // 30*Sequencer_maxDelayBlocks


### PR DESCRIPTION
Restrict the types of transactions that can be accepted if signed by a non-EIP-155 signature. In particular, we reject the signature on a transaction unless it is a deploy transaction, and has sequence number (nonce) of zero, and has zero callvalue.

The purpose of the restriction is to avoid attacks that replay Ethereum transactions from the pre-EIP-155 era. In particular, we don't want to allow old payment transactions to be replayed.

We do allow such signatures in a restricted case, to ensure that keyless deployments will still work.

This PR also refactors the TxRequestData struct.