### PR TITLE
Add #[serde(default)] for various fields, in order to match C++ format

### DIFF
--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -31,6 +31,7 @@ mod xformcode;
 pub struct LinkedProgram {
     pub code: Vec<Instruction<AVMOpcode>>,
     pub static_val: Value,
+    #[serde(default)]
     pub file_name_chart: BTreeMap<u64, String>,
 }
 

--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -89,6 +89,7 @@ impl LabelGenerator {
 pub struct Instruction<T = Opcode> {
     pub opcode: T,
     pub immediate: Option<Value>,
+    #[serde(default)]
     pub debug_info: DebugInfo,
 }
 


### PR DESCRIPTION
Allows the C++ format for mexe files to be used in this repo via use of serde default flags for various fields.