### PR TITLE
Merge match patterns

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -545,11 +545,16 @@ pub enum StatementKind {
     DebugPrint(Expr),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MatchPattern {
+    pub(crate) kind: MatchPatternKind<MatchPattern>,
+}
+
 ///Either a single identifier or a tuple of identifiers, used in mini let bindings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum MatchPattern {
+pub enum MatchPatternKind<T> {
     Simple(StringId),
-    Tuple(Vec<MatchPattern>),
+    Tuple(Vec<T>),
 }
 
 ///Represents a constant mini value of type Option<T> for some type T.

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -546,8 +546,9 @@ pub enum StatementKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MatchPattern {
-    pub(crate) kind: MatchPatternKind<MatchPattern>,
+pub struct MatchPattern<T = ()> {
+    pub(crate) kind: MatchPatternKind<MatchPattern<T>>,
+    pub(crate) cached: T,
 }
 
 ///Either a single identifier or a tuple of identifiers, used in mini let bindings.

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -558,6 +558,21 @@ pub enum MatchPatternKind<T> {
     Tuple(Vec<T>),
 }
 
+impl<T> MatchPattern<T> {
+    pub fn new_simple(id: StringId, cached: T) -> Self {
+        Self {
+            kind: MatchPatternKind::Simple(id),
+            cached,
+        }
+    }
+    pub fn new_tuple(id: Vec<MatchPattern<T>>, cached: T) -> Self {
+        Self {
+            kind: MatchPatternKind::Tuple(id),
+            cached,
+        }
+    }
+}
+
 ///Represents a constant mini value of type Option<T> for some type T.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OptionConst {

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -155,7 +155,7 @@ fn inline(
                             kind: TypeCheckedStatementKind::Let(
                                 TypeCheckedMatchPattern {
                                     kind: MatchPatternKind::Simple(otherarg.name),
-                                    tipe: otherarg.tipe.clone(),
+                                    cached: otherarg.tipe.clone(),
                                 },
                                 arg.clone(),
                             ),
@@ -278,12 +278,7 @@ impl AbstractSyntaxTree for TypeCheckedStatement {
     }
 }
 
-///A `MatchPattern` that has gone through type checking.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct TypeCheckedMatchPattern {
-    pub(crate) kind: MatchPatternKind<TypeCheckedMatchPattern>,
-    tipe: Type,
-}
+pub type TypeCheckedMatchPattern = MatchPattern<Type>;
 
 ///A mini expression with associated `DebugInfo` that has been type checked.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -940,7 +935,7 @@ fn typecheck_statement<'a>(
                     TypeCheckedStatementKind::Let(
                         TypeCheckedMatchPattern {
                             kind: MatchPatternKind::Simple(*name),
-                            tipe: tce_type.clone(),
+                            cached: tce_type.clone(),
                         },
                         tc_expr,
                     ),
@@ -953,7 +948,7 @@ fn typecheck_statement<'a>(
                         TypeCheckedStatementKind::Let(
                             TypeCheckedMatchPattern {
                                 kind: MatchPatternKind::Tuple(tc_pats),
-                                tipe: tce_type,
+                                cached: tce_type,
                             },
                             tc_expr,
                         ),
@@ -1107,7 +1102,7 @@ fn typecheck_patvec(
                     MatchPatternKind::Simple(name) => {
                         tc_pats.push(TypeCheckedMatchPattern {
                             kind: MatchPatternKind::Simple(*name),
-                            tipe: rhs_type.clone(),
+                            cached: rhs_type.clone(),
                         });
                         bindings.push((*name, rhs_type.clone()));
                     }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -153,10 +153,10 @@ fn inline(
                         .zip(func.args.iter())
                         .map(|(arg, otherarg)| TypeCheckedStatement {
                             kind: TypeCheckedStatementKind::Let(
-                                TypeCheckedMatchPattern {
-                                    kind: MatchPatternKind::Simple(otherarg.name),
-                                    cached: otherarg.tipe.clone(),
-                                },
+                                TypeCheckedMatchPattern::new_simple(
+                                    otherarg.name,
+                                    otherarg.tipe.clone(),
+                                ),
                                 arg.clone(),
                             ),
                             debug_info: DebugInfo::default(),
@@ -933,10 +933,7 @@ fn typecheck_statement<'a>(
             match &pat.kind {
                 MatchPatternKind::Simple(name) => Ok((
                     TypeCheckedStatementKind::Let(
-                        TypeCheckedMatchPattern {
-                            kind: MatchPatternKind::Simple(*name),
-                            cached: tce_type.clone(),
-                        },
+                        TypeCheckedMatchPattern::new_simple(*name, tce_type.clone()),
                         tc_expr,
                     ),
                     vec![(*name, tce_type)],
@@ -946,10 +943,7 @@ fn typecheck_statement<'a>(
                         typecheck_patvec(tce_type.clone(), pats.to_vec(), debug_info.location)?;
                     Ok((
                         TypeCheckedStatementKind::Let(
-                            TypeCheckedMatchPattern {
-                                kind: MatchPatternKind::Tuple(tc_pats),
-                                cached: tce_type,
-                            },
+                            TypeCheckedMatchPattern::new_tuple(tc_pats, tce_type),
                             tc_expr,
                         ),
                         bindings,
@@ -1100,10 +1094,7 @@ fn typecheck_patvec(
                 let pat = &patterns[i];
                 match &pat.kind {
                     MatchPatternKind::Simple(name) => {
-                        tc_pats.push(TypeCheckedMatchPattern {
-                            kind: MatchPatternKind::Simple(*name),
-                            cached: rhs_type.clone(),
-                        });
+                        tc_pats.push(TypeCheckedMatchPattern::new_simple(*name, rhs_type.clone()));
                         bindings.push((*name, rhs_type.clone()));
                     }
                     MatchPatternKind::Tuple(_) => {

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -6,8 +6,8 @@
 
 use super::ast::{
     BinaryOp, CodeBlock, Constant, DebugInfo, Expr, ExprKind, FuncArg, FuncDecl, FuncDeclKind,
-    GlobalVarDecl, MatchPattern, Statement, StatementKind, StructField, TopLevelDecl, TrinaryOp,
-    Type, TypeTree, UnaryOp,
+    GlobalVarDecl, MatchPattern, MatchPatternKind, Statement, StatementKind, StructField,
+    TopLevelDecl, TrinaryOp, Type, TypeTree, UnaryOp,
 };
 use crate::link::{ExportedFunc, Import, ImportedFunc};
 use crate::mavm::{Instruction, Label, Value};
@@ -153,10 +153,10 @@ fn inline(
                         .zip(func.args.iter())
                         .map(|(arg, otherarg)| TypeCheckedStatement {
                             kind: TypeCheckedStatementKind::Let(
-                                TypeCheckedMatchPattern::Simple(
-                                    otherarg.name,
-                                    otherarg.tipe.clone(),
-                                ),
+                                TypeCheckedMatchPattern {
+                                    kind: MatchPatternKind::Simple(otherarg.name),
+                                    tipe: otherarg.tipe.clone(),
+                                },
                                 arg.clone(),
                             ),
                             debug_info: DebugInfo::default(),
@@ -280,9 +280,9 @@ impl AbstractSyntaxTree for TypeCheckedStatement {
 
 ///A `MatchPattern` that has gone through type checking.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum TypeCheckedMatchPattern {
-    Simple(StringId, Type),
-    Tuple(Vec<TypeCheckedMatchPattern>, Type),
+pub struct TypeCheckedMatchPattern {
+    pub(crate) kind: MatchPatternKind<TypeCheckedMatchPattern>,
+    tipe: Type,
 }
 
 ///A mini expression with associated `DebugInfo` that has been type checked.
@@ -935,20 +935,26 @@ fn typecheck_statement<'a>(
                 scopes,
             )?;
             let tce_type = tc_expr.get_type();
-            match pat {
-                MatchPattern::Simple(name) => Ok((
+            match &pat.kind {
+                MatchPatternKind::Simple(name) => Ok((
                     TypeCheckedStatementKind::Let(
-                        TypeCheckedMatchPattern::Simple(*name, tce_type.clone()),
+                        TypeCheckedMatchPattern {
+                            kind: MatchPatternKind::Simple(*name),
+                            tipe: tce_type.clone(),
+                        },
                         tc_expr,
                     ),
                     vec![(*name, tce_type)],
                 )),
-                MatchPattern::Tuple(pats) => {
+                MatchPatternKind::Tuple(pats) => {
                     let (tc_pats, bindings) =
                         typecheck_patvec(tce_type.clone(), pats.to_vec(), debug_info.location)?;
                     Ok((
                         TypeCheckedStatementKind::Let(
-                            TypeCheckedMatchPattern::Tuple(tc_pats, tce_type),
+                            TypeCheckedMatchPattern {
+                                kind: MatchPatternKind::Tuple(tc_pats),
+                                tipe: tce_type,
+                            },
                             tc_expr,
                         ),
                         bindings,
@@ -1097,12 +1103,15 @@ fn typecheck_patvec(
             let mut bindings = Vec::new();
             for (i, rhs_type) in tvec.iter().enumerate() {
                 let pat = &patterns[i];
-                match pat {
-                    MatchPattern::Simple(name) => {
-                        tc_pats.push(TypeCheckedMatchPattern::Simple(*name, rhs_type.clone()));
+                match &pat.kind {
+                    MatchPatternKind::Simple(name) => {
+                        tc_pats.push(TypeCheckedMatchPattern {
+                            kind: MatchPatternKind::Simple(*name),
+                            tipe: rhs_type.clone(),
+                        });
                         bindings.push((*name, rhs_type.clone()));
                     }
-                    MatchPattern::Tuple(_) => {
+                    MatchPatternKind::Tuple(_) => {
                         //TODO: implement this properly
                         return Err(new_type_error(
                             "nested pattern not yet supported in let".to_string(),

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -4,7 +4,7 @@
 
 
 use crate::compile::ast::{TopLevelDecl, TypeDecl, FuncDecl, GlobalVarDecl, Type, CodeBlock,
-StructField, FuncArg, Statement, StatementKind, DebugInfo, Attributes, MatchPattern, Expr, ExprKind, TrinaryOp, BinaryOp, UnaryOp, Constant,
+StructField, FuncArg, Statement, StatementKind, DebugInfo, Attributes, MatchPattern, MatchPatternKind, Expr, ExprKind, TrinaryOp, BinaryOp, UnaryOp, Constant,
 OptionConst, FieldInitializer, new_func_arg, new_type_decl};
 use crate::stringtable::{StringTable, StringId};
 use crate::compile::Lines;
@@ -103,8 +103,8 @@ StatementKind: StatementKind = {
 }
 
 MatchPattern: MatchPattern = {
-	<Ident> => MatchPattern::Simple(<>),
-	"(" <CommaedMatchPatterns> ")" => MatchPattern::Tuple(<>),
+	<Ident> => MatchPattern { kind: MatchPatternKind::Simple(<>)},
+	"(" <CommaedMatchPatterns> ")" => MatchPattern { kind: MatchPatternKind::Tuple(<>)},
 }
 
 CommaedMatchPatterns: Vec<MatchPattern> = {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -103,8 +103,8 @@ StatementKind: StatementKind = {
 }
 
 MatchPattern: MatchPattern = {
-	<Ident> => MatchPattern { kind: MatchPatternKind::Simple(<>), cached: ()},
-	"(" <CommaedMatchPatterns> ")" => MatchPattern { kind: MatchPatternKind::Tuple(<>), cached: ()},
+	<Ident> => MatchPattern::new_simple(<>,()),
+	"(" <CommaedMatchPatterns> ")" => MatchPattern::new_tuple(<>,()),
 }
 
 CommaedMatchPatterns: Vec<MatchPattern> = {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -103,8 +103,8 @@ StatementKind: StatementKind = {
 }
 
 MatchPattern: MatchPattern = {
-	<Ident> => MatchPattern { kind: MatchPatternKind::Simple(<>)},
-	"(" <CommaedMatchPatterns> ")" => MatchPattern { kind: MatchPatternKind::Tuple(<>)},
+	<Ident> => MatchPattern { kind: MatchPatternKind::Simple(<>), cached: ()},
+	"(" <CommaedMatchPatterns> ")" => MatchPattern { kind: MatchPatternKind::Tuple(<>), cached: ()},
 }
 
 CommaedMatchPatterns: Vec<MatchPattern> = {


### PR DESCRIPTION
Merges the definitions of MatchPattern and TypeCheckedMatchPattern via use of generics.  This is necessary to effectively merge type checked versions of more complex ast nodes, and reduces the number of locations one needs to change to edit the match pattern definition.