### PR TITLE
Merge struct initializers and funcs

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -56,7 +56,7 @@ impl From<Option<Location>> for DebugInfo {
 #[derive(Debug, Clone)]
 pub enum TopLevelDecl {
     TypeDecl(TypeDecl),
-    FuncDecl(FuncDecl),
+    FuncDecl(Func),
     VarDecl(GlobalVarDecl),
     UseDecl(Vec<String>, String),
 }
@@ -481,18 +481,18 @@ pub enum FuncDeclKind {
 ///Represents a top level function declaration.  The is_impure, args, and ret_type fields are
 /// assumed to be derived from tipe, and this must be upheld by the user of this type.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FuncDecl {
+pub struct Func<T = Statement> {
     pub name: StringId,
     pub args: Vec<FuncArg>,
     pub ret_type: Type,
-    pub code: Vec<Statement>,
+    pub code: Vec<T>,
     pub tipe: Type,
     pub kind: FuncDeclKind,
-    pub location: Option<Location>,
+    pub debug_info: DebugInfo,
     pub properties: PropertiesList,
 }
 
-impl FuncDecl {
+impl Func {
     pub fn new(
         name: StringId,
         is_impure: bool,
@@ -507,7 +507,7 @@ impl FuncDecl {
         for arg in args.iter() {
             arg_types.push(arg.tipe.clone());
         }
-        FuncDecl {
+        Func {
             name,
             args: args_vec,
             ret_type: ret_type.clone(),
@@ -518,7 +518,7 @@ impl FuncDecl {
             } else {
                 FuncDeclKind::Private
             },
-            location,
+            debug_info: DebugInfo::from(location),
             properties: PropertiesList { pure: !is_impure },
         }
     }

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -5,6 +5,7 @@
 //!Contains types and utilities for constructing the mini AST
 
 use super::typecheck::{new_type_error, TypeError};
+use crate::compile::typecheck::PropertiesList;
 use crate::link::{value_from_field_list, TUPLE_SIZE};
 use crate::mavm::{Instruction, Value};
 use crate::pos::Location;
@@ -12,7 +13,6 @@ use crate::stringtable::StringId;
 use crate::uint256::Uint256;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use crate::compile::typecheck::PropertiesList;
 
 ///This is a map of the types at a given location, with the Vec<String> representing the module path
 ///and the usize representing the stringID of the type at that location.

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -12,6 +12,7 @@ use crate::stringtable::StringId;
 use crate::uint256::Uint256;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use crate::compile::typecheck::PropertiesList;
 
 ///This is a map of the types at a given location, with the Vec<String> representing the module path
 ///and the usize representing the stringID of the type at that location.
@@ -482,13 +483,13 @@ pub enum FuncDeclKind {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FuncDecl {
     pub name: StringId,
-    pub is_impure: bool,
     pub args: Vec<FuncArg>,
     pub ret_type: Type,
     pub code: Vec<Statement>,
     pub tipe: Type,
     pub kind: FuncDeclKind,
     pub location: Option<Location>,
+    pub properties: PropertiesList,
 }
 
 impl FuncDecl {
@@ -508,7 +509,6 @@ impl FuncDecl {
         }
         FuncDecl {
             name,
-            is_impure,
             args: args_vec,
             ret_type: ret_type.clone(),
             code,
@@ -519,6 +519,7 @@ impl FuncDecl {
                 FuncDeclKind::Private
             },
             location,
+            properties: PropertiesList { pure: !is_impure },
         }
     }
 }

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -757,13 +757,13 @@ pub enum TrinaryOp {
 
 ///Used in StructInitializer expressions to map expressions to fields of the struct.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FieldInitializer {
+pub struct FieldInitializer<T = Expr> {
     pub name: String,
-    pub value: Expr,
+    pub value: T,
 }
 
-impl FieldInitializer {
-    pub fn new(name: String, value: Expr) -> Self {
+impl<T> FieldInitializer<T> {
+    pub fn new(name: String, value: T) -> Self {
         FieldInitializer { name, value }
     }
 }

--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -59,19 +59,17 @@ pub fn mavm_codegen(
     let mut label_gen = LabelGenerator::new();
     let mut funcs_code = BTreeMap::new();
     for func in funcs {
-        if !func.imported {
-            let id = func.name;
-            let (lg, function_code) = mavm_codegen_func(
-                func,
-                label_gen,
-                string_table,
-                &import_func_map,
-                &global_var_map,
-                file_name_chart,
-            )?;
-            label_gen = lg;
-            funcs_code.insert(id, function_code);
-        }
+        let id = func.name;
+        let (lg, function_code) = mavm_codegen_func(
+            func,
+            label_gen,
+            string_table,
+            &import_func_map,
+            &global_var_map,
+            file_name_chart,
+        )?;
+        label_gen = lg;
+        funcs_code.insert(id, function_code);
     }
     let mut code = Vec::new();
     for (_id, mut func) in funcs_code {

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -8,7 +8,7 @@ use crate::link::{ExportedFunc, Import, ImportedFunc};
 use crate::mavm::Instruction;
 use crate::pos::{BytePos, Location};
 use crate::stringtable::StringTable;
-use ast::{FuncDecl, GlobalVarDecl, TypeTree};
+use ast::{Func, GlobalVarDecl, TypeTree};
 use lalrpop_util::lalrpop_mod;
 use mini::DeclsParser;
 use miniconstants::init_constant_table;
@@ -39,7 +39,7 @@ struct Module {
     ///The list of imported functions imported through the old import/export system
     imported_funcs: Vec<ImportedFunc>,
     ///List of functions defined locally within the source file
-    funcs: Vec<FuncDecl>,
+    funcs: Vec<Func>,
     ///Map from `StringId`s in this file to the `Type`s they represent.
     named_types: HashMap<usize, Type>,
     ///List of global variables defined within this file.
@@ -73,7 +73,7 @@ struct TypeCheckedModule {
 impl Module {
     fn new(
         imported_funcs: Vec<ImportedFunc>,
-        funcs: Vec<FuncDecl>,
+        funcs: Vec<Func>,
         named_types: HashMap<usize, Type>,
         global_vars: Vec<GlobalVarDecl>,
         string_table: StringTable,

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -15,8 +15,8 @@ use crate::mavm::{Instruction, Label, Value};
 use crate::pos::Location;
 use crate::stringtable::{StringId, StringTable};
 use crate::uint256::Uint256;
-use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 type TypeTable = HashMap<usize, Type>;
 
@@ -100,7 +100,7 @@ pub struct TypeCheckedFunc {
     pub ret_type: Type,
     pub code: Vec<TypeCheckedStatement>,
     pub tipe: Type,
-    pub imported: bool,
+    pub kind: FuncDeclKind,
     pub debug_info: DebugInfo,
     pub properties: PropertiesList,
 }
@@ -700,7 +700,7 @@ pub fn typecheck_function(
         ret_type: fd.ret_type.clone(),
         code: tc_stats,
         tipe: fd.tipe.clone(),
-        imported: false,
+        kind: fd.kind,
         debug_info: DebugInfo::from(fd.location),
         properties: fd.properties.clone(),
     })

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -5,9 +5,9 @@
 //!Converts non-type checked ast nodes to type checked versions, and other related utilities.
 
 use super::ast::{
-    BinaryOp, CodeBlock, Constant, DebugInfo, Expr, ExprKind, FuncArg, FuncDecl, FuncDeclKind,
-    GlobalVarDecl, MatchPattern, MatchPatternKind, Statement, StatementKind, StructField,
-    TopLevelDecl, TrinaryOp, Type, TypeTree, UnaryOp,
+    BinaryOp, CodeBlock, Constant, DebugInfo, Expr, ExprKind, Func, FuncDeclKind, GlobalVarDecl,
+    MatchPattern, MatchPatternKind, Statement, StatementKind, StructField, TopLevelDecl, TrinaryOp,
+    Type, TypeTree, UnaryOp,
 };
 use crate::compile::ast::FieldInitializer;
 use crate::link::{ExportedFunc, Import, ImportedFunc};
@@ -92,18 +92,7 @@ pub struct PropertiesList {
     pub pure: bool,
 }
 
-///A mini function that has been type checked.
-#[derive(Debug, Clone)]
-pub struct TypeCheckedFunc {
-    pub name: StringId,
-    pub args: Vec<FuncArg>,
-    pub ret_type: Type,
-    pub code: Vec<TypeCheckedStatement>,
-    pub tipe: Type,
-    pub kind: FuncDeclKind,
-    pub debug_info: DebugInfo,
-    pub properties: PropertiesList,
-}
+pub type TypeCheckedFunc = Func<TypeCheckedStatement>;
 
 impl AbstractSyntaxTree for TypeCheckedFunc {
     fn child_nodes(&mut self) -> Vec<TypeCheckedNode> {
@@ -554,7 +543,7 @@ pub fn sort_top_level_decls(
     decls: &[TopLevelDecl],
 ) -> (
     Vec<Import>,
-    Vec<FuncDecl>,
+    Vec<Func>,
     HashMap<usize, Type>,
     Vec<GlobalVarDecl>,
     HashMap<usize, Type>,
@@ -588,7 +577,7 @@ pub fn sort_top_level_decls(
 ///Performs typechecking various top level declarations, including `ImportedFunc`s, `FuncDecl`s,
 /// named `Type`s, and global variables.
 pub fn typecheck_top_level_decls(
-    funcs: Vec<FuncDecl>,
+    funcs: Vec<Func>,
     named_types: HashMap<usize, Type>,
     global_vars: Vec<GlobalVarDecl>,
     string_table: StringTable,
@@ -650,7 +639,7 @@ pub fn typecheck_top_level_decls(
 ///
 /// If not successful the function returns a `TypeError`.
 pub fn typecheck_function(
-    fd: &FuncDecl,
+    fd: &Func,
     type_table: &TypeTable,
     global_vars: &HashMap<StringId, (Type, usize)>,
     func_table: &TypeTable,
@@ -701,7 +690,7 @@ pub fn typecheck_function(
         code: tc_stats,
         tipe: fd.tipe.clone(),
         kind: fd.kind,
-        debug_info: DebugInfo::from(fd.location),
+        debug_info: DebugInfo::from(fd.debug_info),
         properties: fd.properties.clone(),
     })
 }

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -16,6 +16,7 @@ use crate::pos::Location;
 use crate::stringtable::{StringId, StringTable};
 use crate::uint256::Uint256;
 use std::collections::{HashMap, HashSet};
+use serde::{Deserialize, Serialize};
 
 type TypeTable = HashMap<usize, Type>;
 
@@ -86,7 +87,7 @@ pub fn new_type_error(msg: String, location: Option<Location>) -> TypeError {
 
 ///Keeps track of compiler enforced properties, currently only tracks purity, may be extended to
 /// keep track of potential to throw or other properties.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PropertiesList {
     pub pure: bool,
 }
@@ -701,9 +702,7 @@ pub fn typecheck_function(
         tipe: fd.tipe.clone(),
         imported: false,
         debug_info: DebugInfo::from(fd.location),
-        properties: PropertiesList {
-            pure: !fd.is_impure,
-        },
+        properties: fd.properties.clone(),
     })
 }
 

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -3,8 +3,8 @@
 //
 
 
-use crate::compile::ast::{TopLevelDecl, TypeDecl, FuncDecl, GlobalVarDecl, Type, CodeBlock,
-StructField, FuncArg, Statement, StatementKind, DebugInfo, Attributes, MatchPattern, MatchPatternKind, Expr, ExprKind, TrinaryOp, BinaryOp, UnaryOp, Constant,
+use crate::compile::ast::{TopLevelDecl, TypeDecl, Func, GlobalVarDecl, Type, CodeBlock,
+StructField, FuncArg, Statement, StatementKind, DebugInfo, Attributes, MatchPattern, Expr, ExprKind, TrinaryOp, BinaryOp, UnaryOp, Constant,
 OptionConst, FieldInitializer, new_func_arg, new_type_decl};
 use crate::stringtable::{StringTable, StringId};
 use crate::compile::Lines;
@@ -47,9 +47,9 @@ TypeDecl: TypeDecl = {
 	"type" <Ident> "=" <Type> => new_type_decl(<>),
 }
 
-FuncDecl: FuncDecl = {
+FuncDecl: Func = {
 	<lno: @L> <p: "public"?> <imp: "impure"?> "func" <i:Ident> "(" <fa:FuncArgs> ")" <t: ("->" <Type>)?> <cb:CodeBlock> =>
-	        FuncDecl::new(i, imp.is_some(), fa, t.unwrap_or(Type::Void), cb, p.is_some(), file_info.location(BytePos::from(lno),filename)),
+	        Func::new(i, imp.is_some(), fa, t.unwrap_or(Type::Void), cb, p.is_some(), file_info.location(BytePos::from(lno),filename)),
 }
 
 FuncArgs: Vec<FuncArg> = {


### PR DESCRIPTION
Merges `FieldInitializer` with `TypeCheckedStructField`, and `FuncDecl` with `TypeCheckedFunc`, reducing complexity and duplication of fields.