### PR TITLE
Fix loop termination bug

### DIFF
--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -828,7 +828,7 @@ impure func updateCongestionState(state: CongestionState, toBlockNum: uint, toTi
 
     // doing a per-second loop isn't elegant, but cost is low enough that it shouldn't be a problem
     // eventually we should solve this analytically to avoid the per-second loop
-    while((lastTimestampSeen < toTimestamp) && ( (state.gasPool < int(gasAccountingParams.GasPoolMax)) || (totalPrice > basePrice) )) {
+    while((lastTimestampSeen < toTimestamp) && ( (gasPool < int(gasAccountingParams.GasPoolMax)) || (totalPrice > basePrice) )) {
         lastTimestampSeen = lastTimestampSeen + 1;
         gasPool = gasPool + int(speedLimit);
         if (gasPool > int(gasAccountingParams.GasPoolMax)) {


### PR DESCRIPTION
Fix bug in loop termination condition. This was causing the loop to run for too long, which didn't affect results but could waste considerable resources.