### PR TITLE
Fix typo and expect speed limit param to be in blocks

### DIFF
--- a/arb_os/chainParameters.mini
+++ b/arb_os/chainParameters.mini
@@ -45,10 +45,11 @@ public impure func chainParams_gotParamsMessage(sender: address, data: ByteArray
     if (globalChainParams == None<ChainParams>) {
         arbowner_init();
 
+        let arbGasSpeedLimitPerBlock = bytearray_get256(data, 32);
         globalChainParams = Some(struct{
             chainAddress: sender,
-            gracePeriodBlockss: bytearray_get256(data, 0),
-            arbGasSpeedLimitPerSecond: bytearray_get256(data, 32),
+            gracePeriodBlocks: bytearray_get256(data, 0),
+            arbGasSpeedLimitPerSecond: blocksToSeconds(arbGasSpeedLimitPerBlock),
             maxExecutionSteps: bytearray_get256(data, 2*32),
             baseStake: bytearray_get256(data, 3*32),
             stakingToken: address(bytearray_get256(data, 4*32)),


### PR DESCRIPTION
* Fix typo in chainParameters
* Expect the chain init message to give ArbGas speed limit in blocks rather than seconds