### PR TITLE
Do not allow assignment of void values in let statement

### DIFF
--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1078,6 +1078,9 @@ fn typecheck_patvec(
             let mut tc_pats = Vec::new();
             let mut bindings = Vec::new();
             for (i, rhs_type) in tvec.iter().enumerate() {
+                if *rhs_type == Type::Void {
+                    return Err(new_type_error("attempted to assign void in tuple binding".to_string(), location));
+                }
                 let pat = &patterns[i];
                 match &pat.kind {
                     MatchPatternKind::Simple(name) => {

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -911,6 +911,12 @@ fn typecheck_statement<'a>(
                 scopes,
             )?;
             let tce_type = tc_expr.get_type();
+            if tce_type == Type::Void {
+                return Err(new_type_error(
+                    format!("Assignment of void value to local variable"),
+                    debug_info.location,
+                ));
+            }
             match &pat.kind {
                 MatchPatternKind::Simple(name) => Ok((
                     TypeCheckedStatementKind::Let(


### PR DESCRIPTION
This prevents a compiler crash caused by assignment of type void in a let statement.