### PR TITLE
Refactor compile from folder

### DIFF
--- a/src/buffertests.rs
+++ b/src/buffertests.rs
@@ -28,4 +28,3 @@ fn test_hash_test() {
     assert_eq!(hash_buffer(&buf, true), hash_buffer2(buf.to_vec()));
 }
 */
-

--- a/src/compile/miniconstants.rs
+++ b/src/compile/miniconstants.rs
@@ -220,13 +220,13 @@ pub fn init_constant_table() -> HashMap<String, Uint256> {
         ("PluggableModuleID_rollupTracker", 0),
         ("PluggableModuleID_precompile_0x05", 1),
         // retry buffer
-        ("RetryBuffer_DefaultLifetimeSeconds", 60*60*24*7),
+        ("RetryBuffer_DefaultLifetimeSeconds", 60 * 60 * 24 * 7),
         // gas cost values for re-entrancy protection
         ("EVMWriteL1GasCost", 5000),
         ("EVMNonZeroBalanceCallStipend", 2300),
         ("ArbitrumNonZeroBalanceCallStipend", 20000),
         // misc
-        ("TwoToThe32", 1<<32),
+        ("TwoToThe32", 1 << 32),
         ("SecondsPerBlockNumerator", 2),
         ("SecondsPerBlockDenominator", 1),
         ("DefaultSpeedLimitPerSecond", 100_000_000),

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -332,11 +332,9 @@ pub fn compile_from_folder(
     file_name_chart: &mut BTreeMap<u64, String>,
     inline: bool,
 ) -> Result<Vec<CompiledProgram>, CompileError> {
-    //Parsing step
     let (mut programs, import_map) = create_program_tree(folder, library, main, file_name_chart)?;
-    //Resolution of imports (use statements)
     resolve_imports(&mut programs, &import_map)?;
-    //Conversion of programs `HashMap` to `Vec` for typechecking
+    //Conversion of programs from `HashMap` to `Vec` for typechecking
     let type_tree = create_type_tree(&programs);
     let mut output = vec![programs
         .remove(&if let Some(lib) = library {
@@ -350,18 +348,11 @@ pub fn compile_from_folder(
         out.sort_by(|module1, module2| module2.name.cmp(&module1.name));
         out
     });
-    //Typechecking loop
     let mut typechecked = typecheck_programs(&type_tree, output)?;
-    /*for module in &mut typechecked {
-        for _func in &mut module.checked_funcs {
-            func.recursive_apply(print_node, &"    ".to_string(), &mut 0);
-        }
-    }*/
     //Inlining stage
     if inline {
         typechecked.iter_mut().for_each(|module| module.inline());
     }
-    //Codegen loop
     let progs = codegen_programs(typechecked, file_name_chart, folder)?;
     Ok(progs)
 }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -351,7 +351,9 @@ pub fn compile_from_folder(
     let mut typechecked_modules = typecheck_programs(&type_tree, modules)?;
     //Inlining stage
     if inline {
-        typechecked_modules.iter_mut().for_each(|module| module.inline());
+        typechecked_modules
+            .iter_mut()
+            .for_each(|module| module.inline());
     }
     let progs = codegen_programs(typechecked_modules, file_name_chart, folder)?;
     Ok(progs)

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1079,7 +1079,10 @@ fn typecheck_patvec(
             let mut bindings = Vec::new();
             for (i, rhs_type) in tvec.iter().enumerate() {
                 if *rhs_type == Type::Void {
-                    return Err(new_type_error("attempted to assign void in tuple binding".to_string(), location));
+                    return Err(new_type_error(
+                        "attempted to assign void in tuple binding".to_string(),
+                        location,
+                    ));
                 }
                 let pat = &patterns[i];
                 match &pat.kind {

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -235,7 +235,7 @@ impl RuntimeEnvironment {
                 Some(Uint256::from_bytes(&keccak256(&buf2)))
             } else {
                 None
-            }
+            },
         )
     }
 

--- a/src/run/upload.rs
+++ b/src/run/upload.rs
@@ -196,7 +196,10 @@ fn _test_upgrade_arbos_over_itself_impl() -> Result<(), ethabi::Error> {
     let arbowner = _ArbOwner::_new(&wallet, false);
 
     let arbsys_orig_binding = ArbSys::new(&wallet, false);
-    assert_eq!(arbsys_orig_binding._arbos_version(&mut machine)?, Uint256::one());
+    assert_eq!(
+        arbsys_orig_binding._arbos_version(&mut machine)?,
+        Uint256::one()
+    );
 
     arbowner._give_ownership(&mut machine, my_addr, Some(Uint256::zero()))?;
 


### PR DESCRIPTION
This separates out each compilation stage into its own function rather than keeping all of the logic in the `compile_from_folder` function.  This will help with testing of each stage, and will make configuration of alternate compilation pipelines easier.