### PR TITLE
Start new segment with zero opcode

### DIFF
--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -891,6 +891,7 @@ pub enum Opcode {
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, Eq, PartialEq, Hash)]
 #[repr(u8)]
 pub enum AVMOpcode {
+    Zero = 0x00,
     Plus = 0x01,
     Mul,
     Minus,
@@ -1155,6 +1156,7 @@ impl AVMOpcode {
             AVMOpcode::ErrPush => "errpush",
             AVMOpcode::Inbox => "inbox",
             AVMOpcode::Panic => "panic",
+            AVMOpcode::Zero => "zero",
             AVMOpcode::Halt => "halt",
             AVMOpcode::InboxPeek => "inboxpeek",
             AVMOpcode::Jump => "jump",
@@ -1188,6 +1190,7 @@ impl AVMOpcode {
 
     pub fn from_number(num: usize) -> Option<Self> {
         match num {
+            0x00 => Some(AVMOpcode::Zero),
             0x01 => Some(AVMOpcode::Plus),
             0x02 => Some(AVMOpcode::Mul),
             0x03 => Some(AVMOpcode::Minus),
@@ -1276,6 +1279,7 @@ impl AVMOpcode {
 
     pub fn to_number(&self) -> u8 {
         match self {
+            AVMOpcode::Zero => 0,
             AVMOpcode::Plus => 0x01,
             AVMOpcode::Mul => 0x02,
             AVMOpcode::Minus => 0x03,

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -308,7 +308,7 @@ impl CodeStore {
     /// to the start of that segment.
     fn create_segment(&mut self) -> CodePt {
         self.segments.push(vec![Instruction::from_opcode(
-            AVMOpcode::Panic,
+            AVMOpcode::Zero,
             DebugInfo::default(),
         )]);
         CodePt::new_in_segment(self.segments.len() - 1, 0)
@@ -1168,6 +1168,7 @@ impl Machine {
     pub(crate) fn next_op_gas(&self) -> Option<u64> {
         if let MachineState::Running(pc) = self.state {
             Some(match self.code.get_insn(pc)?.opcode {
+                AVMOpcode::Zero => 5,
                 AVMOpcode::Plus => 3,
                 AVMOpcode::Mul => 3,
                 AVMOpcode::Minus => 3,
@@ -1334,6 +1335,7 @@ impl Machine {
                         self.incr_pc();
                         Ok(true)
                     }
+                    AVMOpcode::Zero |
                     AVMOpcode::Panic => Err(ExecutionError::new("panicked", &self.state, None)),
                     AVMOpcode::Jump => {
                         self.state = MachineState::Running(self.stack.pop_codepoint(&self.state)?);


### PR DESCRIPTION
Start each new code segment with a zero opcode, rather than a Panic opcode. This affects the hash of CodePoints.