### PR TITLE
Type error reporting improvments

### DIFF
--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -5,6 +5,7 @@
 //!Contains types and utilities for constructing the mini AST
 
 use super::typecheck::{new_type_error, TypeError};
+use crate::compile::ast::TypeMismatch::FuncArgLength;
 use crate::compile::typecheck::{AbstractSyntaxTree, PropertiesList, TypeCheckedNode};
 use crate::link::{value_from_field_list, TUPLE_SIZE};
 use crate::mavm::{Instruction, Value};
@@ -13,6 +14,8 @@ use crate::stringtable::StringId;
 use crate::uint256::Uint256;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::fmt::Formatter;
 
 ///This is a map of the types at a given location, with the Vec<String> representing the module path
 ///and the usize representing the stringID of the type at that location.
@@ -255,6 +258,152 @@ impl Type {
         }
     }
 
+    pub fn first_mismatch(
+        &self,
+        rhs: &Self,
+        type_tree: &TypeTree,
+        mut seen: HashSet<(Type, Type)>,
+    ) -> Option<TypeMismatch> {
+        if *rhs == Type::Every {
+            return None;
+        }
+        match self {
+            Type::Any => {
+                if *rhs != Type::Void {
+                    None
+                } else {
+                    Some(TypeMismatch::Type(Type::Any, Type::Void))
+                }
+            }
+            Type::Void
+            | Type::Uint
+            | Type::Int
+            | Type::Bool
+            | Type::Bytes32
+            | Type::EthAddress
+            | Type::Buffer
+            | Type::Every => {
+                if self == rhs {
+                    None
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Tuple(tvec) => {
+                if let Ok(Type::Tuple(tvec2)) = rhs.get_representation(type_tree) {
+                    for (index, (left, right)) in tvec.iter().zip(tvec2.iter()).enumerate() {
+                        if let Some(inner) = left.first_mismatch(right, type_tree, seen.clone()) {
+                            return Some(TypeMismatch::Tuple(index, Box::new(inner)));
+                        }
+                    }
+                    if tvec.len() != tvec2.len() {
+                        return Some(TypeMismatch::TupleLength(tvec.len(), tvec2.len()));
+                    }
+                    None
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Array(t) => {
+                if let Ok(Type::Array(t2)) = rhs.get_representation(type_tree) {
+                    t.first_mismatch(&t2, type_tree, seen)
+                        .map(|mismatch| TypeMismatch::ArrayMismatch(Box::new(mismatch)))
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::FixedArray(t, s) => {
+                if let Ok(Type::FixedArray(t2, s2)) = rhs.get_representation(type_tree) {
+                    if let Some(inner) = t.first_mismatch(&t2, type_tree, seen) {
+                        Some(TypeMismatch::ArrayMismatch(Box::new(inner)))
+                    } else if *s != s2 {
+                        Some(TypeMismatch::ArrayLength(*s, s2))
+                    } else {
+                        None
+                    }
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Struct(fields) => {
+                if let Ok(Type::Struct(fields2)) = rhs.get_representation(type_tree) {
+                    field_vectors_mismatch(fields, &fields2, type_tree, seen)
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Nominal(_, _) => {
+                match (
+                    self.get_representation(type_tree),
+                    rhs.get_representation(type_tree),
+                ) {
+                    (Ok(left), Ok(right)) => {
+                        if seen.insert((self.clone(), rhs.clone())) {
+                            left.first_mismatch(&right, type_tree, seen)
+                        } else {
+                            None
+                        }
+                    }
+                    (Ok(_), Err(_)) => Some(TypeMismatch::UnresolvedRight(self.clone())),
+                    (Err(_), Ok(_)) => Some(TypeMismatch::UnresolvedLeft(rhs.clone())),
+                    (Err(_), Err(_)) => {
+                        Some(TypeMismatch::UnresolvedBoth(self.clone(), rhs.clone()))
+                    }
+                }
+            }
+            Type::Func(is_impure, args, ret) => {
+                if let Type::Func(is_impure2, args2, ret2) = rhs {
+                    for (index, (left, right)) in args.iter().zip(args2.iter()).enumerate() {
+                        if let Some(inner) = left.first_mismatch(right, type_tree, seen.clone()) {
+                            return Some(TypeMismatch::FuncArg(index, Box::new(inner)));
+                        }
+                    }
+                    if args.len() != args2.len() {
+                        return Some(FuncArgLength(args.len(), args2.len()));
+                    }
+                    if let Some(inner) = ret.first_mismatch(ret2, type_tree, seen) {
+                        return Some(TypeMismatch::FuncReturn(Box::new(inner)));
+                    }
+                    if !is_impure && *is_impure2 {
+                        return Some(TypeMismatch::Purity);
+                    }
+                    None
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Map(key1, val1) => {
+                if let Type::Map(key2, val2) = rhs {
+                    if let Ok(val2) = val2.get_representation(type_tree) {
+                        key1.first_mismatch(key2, type_tree, seen.clone())
+                            .map(|mismatch| (true, mismatch))
+                            .or_else(|| {
+                                val1.first_mismatch(&val2, type_tree, seen)
+                                    .map(|mismatch| (false, mismatch))
+                            })
+                            .map(|(is_key, mismatch)| TypeMismatch::Map {
+                                is_key,
+                                inner: Box::new(mismatch),
+                            })
+                    } else {
+                        Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                    }
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+            Type::Option(inner) => {
+                if let Ok(Type::Option(inner2)) = rhs.get_representation(type_tree) {
+                    inner
+                        .first_mismatch(&inner2, type_tree, seen)
+                        .map(|mismatch| TypeMismatch::Option(Box::new(mismatch)))
+                } else {
+                    Some(TypeMismatch::Type(self.clone(), rhs.clone()))
+                }
+            }
+        }
+    }
+
     ///Returns a tuple containing `Type`s default value and a `bool` representing whether use of
     /// that default is type-safe.
     // TODO: have this resolve nominal types
@@ -423,9 +572,29 @@ pub fn arg_vectors_assignable(
             .all(|(t1, t2)| t1.assignable(t2, type_tree, seen.clone()))
 }
 
+pub fn field_vectors_mismatch(
+    tvec1: &[StructField],
+    tvec2: &[StructField],
+    type_tree: &TypeTree,
+    seen: HashSet<(Type, Type)>,
+) -> Option<TypeMismatch> {
+    for (t1, t2) in tvec1.iter().zip(tvec2.iter()) {
+        if let Some(mismatch) = t1.tipe.first_mismatch(&t2.tipe, type_tree, seen.clone()) {
+            return Some(TypeMismatch::FieldType(t1.name.clone(), Box::new(mismatch)));
+        }
+        if t1.name != t2.name {
+            return Some(TypeMismatch::FieldName(t1.name.clone(), t2.name.clone()));
+        }
+    }
+    if tvec1.len() != tvec2.len() {
+        return Some(TypeMismatch::Length(tvec1.len(), tvec2.len()));
+    }
+    None
+}
+
 ///Identical to `type_vectors_assignable` but using StructField slices as inputs and comparing their
 /// inner types.
-pub fn field_vectors_assignable(
+fn field_vectors_assignable(
     tvec1: &[StructField],
     tvec2: &[StructField],
     type_tree: &TypeTree,
@@ -472,6 +641,87 @@ fn type_vectors_equal(v1: &[Type], v2: &[Type]) -> bool {
 ///Returns true if the contents of the slices are equal
 fn struct_field_vectors_equal(f1: &[StructField], f2: &[StructField]) -> bool {
     f1 == f2
+}
+
+#[derive(Debug)]
+pub enum TypeMismatch {
+    Type(Type, Type),
+    FieldName(String, String),
+    FieldType(String, Box<TypeMismatch>),
+    UnresolvedRight(Type),
+    UnresolvedLeft(Type),
+    UnresolvedBoth(Type, Type),
+    Length(usize, usize),
+    ArrayMismatch(Box<TypeMismatch>),
+    ArrayLength(usize, usize),
+    Tuple(usize, Box<TypeMismatch>),
+    TupleLength(usize, usize),
+    FuncArg(usize, Box<TypeMismatch>),
+    FuncArgLength(usize, usize),
+    FuncReturn(Box<TypeMismatch>),
+    Map {
+        is_key: bool,
+        inner: Box<TypeMismatch>,
+    },
+    Option(Box<TypeMismatch>),
+    Purity,
+}
+
+impl fmt::Display for TypeMismatch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                TypeMismatch::Type(left, right) =>
+                    format!("expected {} got {}", left.display(), right.display()),
+                TypeMismatch::FieldType(name, problem) =>
+                    format!("in field \"{}\": {}", name, problem),
+                TypeMismatch::FieldName(left, right) =>
+                    format!("expected field name \"{}\", got \"{}\"", left, right),
+                TypeMismatch::UnresolvedRight(tipe) =>
+                    format!("could not resolve right-hand type \"{}\"", tipe.display()),
+                TypeMismatch::UnresolvedLeft(tipe) =>
+                    format!("could not resolve left-hand type \"{}\"", tipe.display()),
+                TypeMismatch::UnresolvedBoth(left, right) => format!(
+                    "could not resolve both right hand type \"{}\" and left hand type\"{}\"",
+                    left.display(),
+                    right.display()
+                ),
+                TypeMismatch::Length(left, right) => format!(
+                    "structs of different lengths: expected length {} got length {}",
+                    left, right
+                ),
+                TypeMismatch::ArrayLength(left, right) => format!(
+                    "arrays of different lengths: expected length {} got length {}",
+                    left, right
+                ),
+                TypeMismatch::ArrayMismatch(mismatch) =>
+                    format!("inner array type mismatch {}", mismatch),
+                TypeMismatch::Tuple(index, mismatch) =>
+                    format!("in tuple field {}: {}", index + 1, mismatch),
+                TypeMismatch::TupleLength(left, right) => format!(
+                    "tuples of different lengths: expected length {} got length {}",
+                    left, right
+                ),
+                TypeMismatch::FuncArg(index, mismatch) =>
+                    format!("in function argument {}: {}", index + 1, mismatch),
+                TypeMismatch::FuncArgLength(left, right) => format!(
+                    "left func has {} args but right func has {} args",
+                    left, right
+                ),
+                TypeMismatch::FuncReturn(mismatch) =>
+                    format!("in function return type: {}", mismatch),
+                TypeMismatch::Map { is_key, inner } => format!(
+                    "in map {}: {}",
+                    if *is_key { "key" } else { "value" },
+                    inner
+                ),
+                TypeMismatch::Option(mismatch) => format!("in inner option type: {}", mismatch),
+                TypeMismatch::Purity => format!("assigning impure function to pure function"),
+            }
+        )
+    }
 }
 
 ///Field of a struct, contains field name and underlying type.

--- a/src/compile/ast.rs
+++ b/src/compile/ast.rs
@@ -404,6 +404,50 @@ impl Type {
         }
     }
 
+    pub fn mismatch_string(&self, rhs: &Type, type_tree: &TypeTree) -> Option<String> {
+        let (left, right) = (
+            &self.get_representation(type_tree).ok()?,
+            &rhs.get_representation(type_tree).ok()?,
+        );
+        self.first_mismatch(rhs, type_tree, HashSet::new())
+            .map(|mismatch| {
+                format!(
+                    "{}{}",
+                    {
+                        //This will be a lot simpler to write in 1.53 when or-patterns syntax stabilizes
+                        match left {
+                            Type::Any
+                            | Type::Void
+                            | Type::Uint
+                            | Type::Int
+                            | Type::Bool
+                            | Type::Bytes32
+                            | Type::EthAddress
+                            | Type::Buffer
+                            | Type::Every => String::new(),
+                            _ => match right {
+                                Type::Any
+                                | Type::Void
+                                | Type::Uint
+                                | Type::Int
+                                | Type::Bool
+                                | Type::Bytes32
+                                | Type::EthAddress
+                                | Type::Buffer
+                                | Type::Every => String::new(),
+                                _ => format!(
+                                    "\nleft: {}\nright {}\nFirst mismatch: ",
+                                    left.display(),
+                                    right.display()
+                                ),
+                            },
+                        }
+                    },
+                    mismatch
+                )
+            })
+    }
+
     ///Returns a tuple containing `Type`s default value and a `bool` representing whether use of
     /// that default is type-safe.
     // TODO: have this resolve nominal types

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1053,10 +1053,10 @@ fn typecheck_statement<'a>(
                     } else {
                         Err(new_type_error(
                             format!(
-                                "mismatched types in assignment statement expected {}, got {}, first mismatch: {}",
-                                var_type.get_representation(type_tree)?.display(),
-                                tc_expr.get_type().get_representation(type_tree)?.display(),
-                                var_type.first_mismatch(&tc_expr.get_type(), type_tree, HashSet::new()).expect("Did not find mismatch"),
+                                "mismatched types in assignment statement {}",
+                                var_type
+                                    .mismatch_string(&tc_expr.get_type(), type_tree)
+                                    .expect("Did not find mismatch")
                             ),
                             debug_info.location,
                         ))

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -1053,9 +1053,10 @@ fn typecheck_statement<'a>(
                     } else {
                         Err(new_type_error(
                             format!(
-                                "mismatched types in assignment statement expected {}, got {}",
+                                "mismatched types in assignment statement expected {}, got {}, first mismatch: {}",
                                 var_type.get_representation(type_tree)?.display(),
-                                tc_expr.get_type().get_representation(type_tree)?.display()
+                                tc_expr.get_type().get_representation(type_tree)?.display(),
+                                var_type.first_mismatch(&tc_expr.get_type(), type_tree, HashSet::new()).expect("Did not find mismatch"),
                             ),
                             debug_info.location,
                         ))

--- a/src/compile/typecheck.rs
+++ b/src/compile/typecheck.rs
@@ -951,9 +951,14 @@ fn typecheck_statement<'a>(
                     {
                         return Err(new_type_error(
                             format!(
-                                "mismatched types in break statement expected {:?}, got {:?}",
-                                te.map(|te| te.get_type()).unwrap_or(Type::Tuple(vec![])),
-                                tipe
+                                "mismatched types in break statement {}",
+                                te.map(|te| te.get_type())
+                                    .unwrap_or(Type::Tuple(vec![]))
+                                    .mismatch_string(
+                                        &tipe.clone().unwrap_or(Type::Tuple(vec![])),
+                                        type_tree
+                                    )
+                                    .expect("Did not find type mismatch")
                             ),
                             debug_info.location,
                         ));
@@ -1062,27 +1067,30 @@ fn typecheck_statement<'a>(
                         ))
                     }
                 }
-                None => {
-                    match global_vars.get(&*name) {
-                        Some((var_type, idx)) => {
-                            if var_type.assignable(&tc_expr.get_type(), type_tree, HashSet::new()) {
-                                Ok((
-                                    TypeCheckedStatementKind::AssignGlobal(*idx, tc_expr),
-                                    vec![],
-                                ))
-                            } else {
-                                Err(new_type_error(
-                                format!("mismatched types in assignment statement expected {}, got {}", var_type.get_representation(type_tree)?.display(), tc_expr.get_type().get_representation(type_tree)?.display()),
+                None => match global_vars.get(&*name) {
+                    Some((var_type, idx)) => {
+                        if var_type.assignable(&tc_expr.get_type(), type_tree, HashSet::new()) {
+                            Ok((
+                                TypeCheckedStatementKind::AssignGlobal(*idx, tc_expr),
+                                vec![],
+                            ))
+                        } else {
+                            Err(new_type_error(
+                                format!(
+                                    "mismatched types in assignment statement {}",
+                                    var_type
+                                        .mismatch_string(&tc_expr.get_type(), type_tree)
+                                        .expect("Did not find type mismatch")
+                                ),
                                 debug_info.location,
                             ))
-                            }
                         }
-                        None => Err(new_type_error(
-                            "assignment to non-existent variable".to_string(),
-                            debug_info.location,
-                        )),
                     }
-                }
+                    None => Err(new_type_error(
+                        "assignment to non-existent variable".to_string(),
+                        debug_info.location,
+                    )),
+                },
             }
         }
         StatementKind::While(cond, body) => {
@@ -1513,7 +1521,12 @@ fn typecheck_expr(
                                     HashSet::new(),
                                 ) {
                                     return Err(new_type_error(
-                                        format!("wrong argument type in function call, expected \"{}\", got \"{}\"", resolved_arg_type.get_representation(type_tree)?.display(), tc_args[i].get_type().get_representation(type_tree)?.display()),
+                                        format!(
+                                            "wrong argument type in function call, {}",
+                                            resolved_arg_type
+                                                .mismatch_string(&tc_args[i].get_type(), type_tree)
+                                                .expect("Did not find a mismatch")
+                                        ),
                                         loc,
                                     ));
                                 }
@@ -1614,9 +1627,9 @@ fn typecheck_expr(
                         } else {
                             Err(new_type_error(
                                 format!(
-                                    "invalid key value in map lookup, expected \"{}\", got \"{}\"",
-                                    kt.display(),
-                                    tc_idx.get_type().display()
+                                    "invalid key value in map lookup, {}",
+                                    kt.mismatch_string(&tc_idx.get_type(), type_tree)
+                                        .expect("Did not find type mismatch")
                                 ),
                                 loc,
                             ))
@@ -1762,7 +1775,11 @@ fn typecheck_expr(
                             }
                         } else {
                             Err(new_type_error(
-                                format!("mismatched types in array modifier, expected \"{}\", got \"{}\"", t.display(), tc_val.get_type().display()),
+                                format!(
+                                    "mismatched types in array modifier, {}",
+                                    t.mismatch_string(&tc_val.get_type(), type_tree)
+                                        .expect("Did not find type mismatch")
+                                ),
                                 loc,
                             ))
                         }
@@ -1797,13 +1814,21 @@ fn typecheck_expr(
                                 ))
                             } else {
                                 Err(new_type_error(
-                                    format!("invalid value type for map modifier, expected \"{}\", got \"{}\"", vt.display(), tc_val.get_type().display()),
+                                    format!(
+                                        "invalid value type for map modifier, {}",
+                                        vt.mismatch_string(&tc_val.get_type(), type_tree)
+                                            .expect("Did not find type mismatch")
+                                    ),
                                     loc,
                                 ))
                             }
                         } else {
                             Err(new_type_error(
-                                format!("invalid key type for map modifier, expected \"{}\", got \"{}\"", kt.display(), tc_index.get_type().display()),
+                                format!(
+                                    "invalid key type for map modifier, {}",
+                                    kt.mismatch_string(&tc_index.get_type(), type_tree)
+                                        .expect("Did not find type mismatch")
+                                ),
                                 loc,
                             ))
                         }
@@ -1853,7 +1878,13 @@ fn typecheck_expr(
                                 ))
                             } else {
                                 Err(new_type_error(
-                                    format!("incorrect value type in struct modifier, expected \"{}\", found \"{}\"", fields[index].tipe.display(), tc_val.get_type().display()),
+                                    format!(
+                                        "incorrect value type in struct modifier, {}",
+                                        fields[index]
+                                            .tipe
+                                            .mismatch_string(&tc_val.get_type(), type_tree)
+                                            .expect("Did not find type mismatch")
+                                    ),
                                     loc,
                                 ))
                             }


### PR DESCRIPTION
This adds code that locates where the first mismatch between a pair of types is, and uses this code to improve error message reporting.