### PR TITLE
Made parser errors proper compile errors instead of strings + grammer tweak

### DIFF
--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -1272,14 +1272,7 @@ pub fn parse_from_source(
                 format!("{}", &source[offset..end],),
                 vec![lines.location(BytePos::from(offset), file_id).unwrap()],
             ),
-            ParseError::User { error } => CompileError::new(
-                String::from("Internal error"),
-                format!(
-                    "This should be impossible under the new error system {}",
-                    error
-                ),
-                vec![],
-            ),
+            ParseError::User { error } => error,
         })?;
 
     for (constant, loc) in local_constants {

--- a/src/mini.lalrpop
+++ b/src/mini.lalrpop
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 grammar(stringtable: &mut StringTable, file_info: &Lines, filename: u64, current_path: &[String], constants: &mut HashMap<String, Uint256>, local_constants: &mut HashMap<String, Location>, used_constants: &mut HashSet<String>, error_system: &mut ErrorSystem);
 
 extern {
-    type Error = String;
+    type Error = CompileError;
 }
 
 match {
@@ -125,7 +125,7 @@ Statement: Statement = {
 }
 
 Attributes: Attributes = {
-    <lno: @L> <names: (<IdentString> ",")*> <last: IdentString?> =>? {
+    <lno: @L> <names: (<IdentString> ",")*> <last: IdentString?> => {
         let mut attribs = Attributes::default();
         for name in names.into_iter().chain(last.into_iter()) {
             match name.as_ref() {
@@ -146,7 +146,9 @@ Attributes: Attributes = {
                     )
                 ),
             }
-        }; Ok(attribs) },
+        }; 
+        attribs
+    },
 }
 
 StatementKind: StatementKind = {


### PR DESCRIPTION
Makes parser errors proper compiler errors in lalrpop