### PR TITLE
Add gas estimation tests

### DIFF
--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -197,6 +197,52 @@ impl AbiForContract {
         ))
     }
 
+    #[cfg(test)]
+    pub fn estimate_gas_for_function_call(
+        &self,
+        func_name: &str,
+        args: &[ethabi::Token],
+        machine: &mut Machine,
+        payment: Uint256,
+        aggregator: Uint256,
+        wallet: &Wallet,
+        debug: bool,
+    ) -> Result<(Uint256, Vec<Vec<Uint256>>), ethabi::Error> {
+        let this_function = self.contract.function(func_name)?;
+        let calldata = this_function.encode_input(args).unwrap();
+
+        machine.runtime_env.insert_gas_estimation_message(
+            Uint256::from_usize(10_000_000),
+            Uint256::zero(),
+            self.address.clone(),
+            payment,
+            &calldata,
+            aggregator,
+            wallet,
+        );
+
+        let num_logs_before = machine.runtime_env.get_all_receipt_logs().len();
+        let num_sends_before = machine.runtime_env.get_all_sends().len();
+        let _arbgas_used = if debug {
+            machine.debug(None)
+        } else {
+            machine.run(None)
+        };
+        let logs = machine.runtime_env.get_all_receipt_logs();
+        let sends = machine.runtime_env.get_all_sends();
+        assert_eq!(logs.len(), num_logs_before+1);
+        assert_eq!(sends.len(), num_sends_before);
+        assert!(logs[num_logs_before].succeeded());
+
+        let fee_stats = logs[num_logs_before]._get_fee_stats();
+        let wei_stats = &fee_stats[2];
+        let wei_spent = wei_stats[0].add(&wei_stats[1]).add(&wei_stats[2]).add(&wei_stats[3]);
+        let gas_price = &fee_stats[1][3];
+        let gas_estimate = wei_spent.add(gas_price).sub(&Uint256::one()).unwrap().div(gas_price).unwrap();
+
+        Ok((gas_estimate, fee_stats))
+    }
+
     pub fn _send_retryable_tx(
         &self,
         sender: Uint256,
@@ -326,10 +372,11 @@ impl AbiForContract {
                 payment,
                 &calldata,
                 wallet,
+                false,
             );
         machine
             .runtime_env
-            .insert_l2_message(sender_addr, &tx_contents, false);
+            .insert_l2_message(sender_addr, &tx_contents);
 
         let num_logs_before = machine.runtime_env.get_all_receipt_logs().len();
         let num_sends_before = machine.runtime_env.get_all_sends().len();
@@ -368,6 +415,7 @@ impl AbiForContract {
                 payment,
                 calldata,
                 &wallet,
+                false,
             );
 
         Ok((Uint256::from_bytes(&tx_id_bytes)))
@@ -381,6 +429,7 @@ impl AbiForContract {
         machine: &mut Machine,
         payment: Uint256,
         wallet: &Wallet,
+        maybe_max_gas: Option<Uint256>,
     ) -> Result<Uint256, ethabi::Error> {
         let this_function = self.contract.function(func_name)?;
         let calldata = this_function.encode_input(args).unwrap();
@@ -389,12 +438,13 @@ impl AbiForContract {
             .runtime_env
             ._append_compressed_and_signed_tx_message_to_batch(
                 batch,
-                Uint256::from_usize(100_000_000),
+                maybe_max_gas.unwrap_or(Uint256::from_usize(100_000_000)),
                 Uint256::zero(),
                 self.address.clone(),
                 payment,
                 calldata,
                 &wallet,
+                false,
             );
 
         Ok((Uint256::from_bytes(&tx_id_bytes)))

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -230,15 +230,23 @@ impl AbiForContract {
         };
         let logs = machine.runtime_env.get_all_receipt_logs();
         let sends = machine.runtime_env.get_all_sends();
-        assert_eq!(logs.len(), num_logs_before+1);
+        assert_eq!(logs.len(), num_logs_before + 1);
         assert_eq!(sends.len(), num_sends_before);
         assert!(logs[num_logs_before].succeeded());
 
         let fee_stats = logs[num_logs_before]._get_fee_stats();
         let wei_stats = &fee_stats[2];
-        let wei_spent = wei_stats[0].add(&wei_stats[1]).add(&wei_stats[2]).add(&wei_stats[3]);
+        let wei_spent = wei_stats[0]
+            .add(&wei_stats[1])
+            .add(&wei_stats[2])
+            .add(&wei_stats[3]);
         let gas_price = &fee_stats[1][3];
-        let gas_estimate = wei_spent.add(gas_price).sub(&Uint256::one()).unwrap().div(gas_price).unwrap();
+        let gas_estimate = wei_spent
+            .add(gas_price)
+            .sub(&Uint256::one())
+            .unwrap()
+            .div(gas_price)
+            .unwrap();
 
         Ok((gas_estimate, fee_stats))
     }

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -14,6 +14,7 @@ use crate::compile::miniconstants::init_constant_table;
 pub use abi::{builtin_contract_path, contract_path, AbiForContract};
 pub use benchmarks::make_benchmarks;
 pub use evmtest::run_evm_tests;
+use std::option::Option::None;
 
 mod abi;
 mod benchmarks;
@@ -1043,6 +1044,7 @@ pub fn _evm_xcontract_call_using_compressed_batch(
         &mut machine,
         Uint256::from_usize(10000),
         &wallet,
+        None,
     )?;
     let tx_id_2 = pc_contract._add_function_call_to_compressed_batch(
         &mut batch,
@@ -1057,6 +1059,7 @@ pub fn _evm_xcontract_call_using_compressed_batch(
         &mut machine,
         Uint256::zero(),
         &wallet,
+        None,
     )?;
 
     machine
@@ -1296,6 +1299,7 @@ pub fn _evm_xcontract_call_using_compressed_batch_2(
         &mut machine,
         Uint256::from_usize(10000),
         &wallet,
+        None,
     )?;
     let tx_id_2 = pc_contract._add_function_call_to_compressed_batch(
         &mut batch,
@@ -1310,6 +1314,7 @@ pub fn _evm_xcontract_call_using_compressed_batch_2(
         &mut machine,
         Uint256::zero(),
         &wallet,
+        None,
     )?;
 
     machine

--- a/src/evm/preinstalled_contracts.rs
+++ b/src/evm/preinstalled_contracts.rs
@@ -2509,8 +2509,8 @@ impl ArbosTest {
             Some(code),
             Some(storage),
         )?;
-        let _ = machine.runtime_env.get_and_incr_seq_num(&Uint256::zero());
-        let _ = machine.runtime_env.get_and_incr_seq_num(&Uint256::zero());
+        let _ = machine.runtime_env.get_seq_num(&Uint256::zero(), true);
+        let _ = machine.runtime_env.get_seq_num(&Uint256::zero(), true);
         self.call(machine, Uint256::zero(), addr.clone(), calldata, balance)?;
         self._get_marshalled_storage(machine, addr)
     }

--- a/src/minitests/mod.rs
+++ b/src/minitests/mod.rs
@@ -618,7 +618,7 @@ fn test_gas_estimation(use_preferred_aggregator: bool) {
         &mut machine,
         Uint256::zero(),
         &wallet,
-        Some(gas_estimate.add(&Uint256::from_u64(5000))),
+        Some(gas_estimate.add(&Uint256::from_u64(500))),
     ).unwrap();
 
     let num_receipts_before = machine.runtime_env.get_all_receipt_logs().len();

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -234,18 +234,8 @@ impl RuntimeEnvironment {
         Uint256::_from_gwei(200)
     }
 
-    pub fn insert_l2_message(
-        &mut self,
-        sender_addr: Uint256,
-        msg: &[u8],
-    ) -> Uint256 {
-        let default_id = self.insert_l1_message(
-            3,
-            sender_addr.clone(),
-            msg,
-            None,
-            None,
-        );
+    pub fn insert_l2_message(&mut self, sender_addr: Uint256, msg: &[u8]) -> Uint256 {
+        let default_id = self.insert_l1_message(3, sender_addr.clone(), msg, None, None);
         if msg[0] == 0 {
             Uint256::avm_hash2(
                 &sender_addr,
@@ -260,11 +250,7 @@ impl RuntimeEnvironment {
     }
 
     #[cfg(test)]
-    pub fn insert_l2_message_for_gas_estimation(
-        &mut self,
-        sender_addr: Uint256,
-        msg: &[u8],
-    ) {
+    pub fn insert_l2_message_for_gas_estimation(&mut self, sender_addr: Uint256, msg: &[u8]) {
         let _ = self.insert_l1_message(10u8, sender_addr, msg, None, None);
     }
 
@@ -335,7 +321,7 @@ impl RuntimeEnvironment {
             value,
             Vec::from(data),
             wallet,
-            true
+            true,
         );
 
         self.insert_l2_message_for_gas_estimation(aggregator, &buf)

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -144,7 +144,7 @@ impl RuntimeEnvironment {
             .current_timestamp
             .add(&delta_timestamp.unwrap_or(Uint256::from_u64(13).mul(&delta_blocks)));
         if send_heartbeat_message {
-            self.insert_l2_message(Uint256::zero(), &[6u8], false);
+            self.insert_l2_message(Uint256::zero(), &[6u8]);
         }
     }
 
@@ -238,16 +238,15 @@ impl RuntimeEnvironment {
         &mut self,
         sender_addr: Uint256,
         msg: &[u8],
-        is_buddy_deploy: bool,
     ) -> Uint256 {
         let default_id = self.insert_l1_message(
-            if is_buddy_deploy { 5 } else { 3 },
+            3,
             sender_addr.clone(),
             msg,
             None,
             None,
         );
-        if !is_buddy_deploy && (msg[0] == 0) {
+        if msg[0] == 0 {
             Uint256::avm_hash2(
                 &sender_addr,
                 &Uint256::avm_hash2(
@@ -258,6 +257,15 @@ impl RuntimeEnvironment {
         } else {
             default_id
         }
+    }
+
+    #[cfg(test)]
+    pub fn insert_l2_message_for_gas_estimation(
+        &mut self,
+        sender_addr: Uint256,
+        msg: &[u8],
+    ) {
+        let _ = self.insert_l1_message(10u8, sender_addr, msg, None, None);
     }
 
     pub fn insert_l2_message_with_deposit(&mut self, sender_addr: Uint256, msg: &[u8]) -> Uint256 {
@@ -289,7 +297,7 @@ impl RuntimeEnvironment {
         with_deposit: bool,
     ) -> Uint256 {
         let mut buf = vec![0u8];
-        let seq_num = self.get_and_incr_seq_num(&sender_addr.clone());
+        let seq_num = self.get_seq_num(&sender_addr.clone(), true);
         buf.extend(max_gas.to_bytes_be());
         buf.extend(gas_price_bid.to_bytes_be());
         buf.extend(seq_num.to_bytes_be());
@@ -300,8 +308,37 @@ impl RuntimeEnvironment {
         if with_deposit {
             self.insert_l2_message_with_deposit(sender_addr.clone(), &buf)
         } else {
-            self.insert_l2_message(sender_addr.clone(), &buf, false)
+            self.insert_l2_message(sender_addr.clone(), &buf)
         }
+    }
+
+    #[cfg(test)]
+    pub fn insert_gas_estimation_message(
+        &mut self,
+        max_gas: Uint256,
+        gas_price_bid: Uint256,
+        to_addr: Uint256,
+        value: Uint256,
+        data: &[u8],
+        aggregator: Uint256,
+        wallet: &Wallet,
+    ) {
+        let mut buf = vec![3u8];
+        buf.extend(aggregator.to_bytes_be());
+        buf.extend(max_gas.clone().to_bytes_be());
+
+        let _ = self._append_compressed_and_signed_tx_message_to_batch(
+            &mut buf,
+            max_gas,
+            gas_price_bid,
+            to_addr,
+            value,
+            Vec::from(data),
+            wallet,
+            true
+        );
+
+        self.insert_l2_message_for_gas_estimation(aggregator, &buf)
     }
 
     pub fn insert_tx_message_from_contract(
@@ -324,7 +361,7 @@ impl RuntimeEnvironment {
         if with_deposit {
             self.insert_l2_message_with_deposit(sender_addr.clone(), &buf)
         } else {
-            self.insert_l2_message(sender_addr.clone(), &buf, false)
+            self.insert_l2_message(sender_addr.clone(), &buf)
         }
     }
 
@@ -365,10 +402,11 @@ impl RuntimeEnvironment {
         value: Uint256,
         calldata: &[u8],
         wallet: &Wallet,
+        is_gas_estimation: bool,
     ) -> (Vec<u8>, Vec<u8>) {
         let sender = Uint256::from_bytes(wallet.address().as_bytes());
         let mut result = vec![7u8, 0xffu8];
-        let seq_num = self.get_and_incr_seq_num(&sender);
+        let seq_num = self.get_seq_num(&sender, !is_gas_estimation);
         result.extend(seq_num.rlp_encode());
         result.extend(gas_price.rlp_encode());
         result.extend(gas_limit.rlp_encode());
@@ -406,7 +444,7 @@ impl RuntimeEnvironment {
         let mut result = self.compressor.compress_address(sender.clone());
 
         let mut buf = vec![0xffu8];
-        let seq_num = self.get_and_incr_seq_num(&sender);
+        let seq_num = self.get_seq_num(&sender, true);
         buf.extend(seq_num.rlp_encode());
         buf.extend(gas_price.rlp_encode());
         buf.extend(gas_limit.rlp_encode());
@@ -449,7 +487,7 @@ impl RuntimeEnvironment {
             buf.extend(msgs[i].clone());
         }
 
-        self.insert_l2_message(batch_sender.clone(), &buf, false);
+        self.insert_l2_message(batch_sender.clone(), &buf);
     }
 
     pub fn _append_compressed_and_signed_tx_message_to_batch(
@@ -461,6 +499,7 @@ impl RuntimeEnvironment {
         value: Uint256,
         calldata: Vec<u8>,
         wallet: &Wallet,
+        is_gas_estimation: bool,
     ) -> Vec<u8> {
         let (msg, tx_id_bytes) = self.make_compressed_and_signed_l2_message(
             gas_price_bid,
@@ -469,6 +508,7 @@ impl RuntimeEnvironment {
             value,
             &calldata,
             wallet,
+            is_gas_estimation,
         );
         let msg_size: u64 = msg.len().try_into().unwrap();
         let rlp_encoded_len = Uint256::from_u64(msg_size).rlp_encode();
@@ -478,7 +518,7 @@ impl RuntimeEnvironment {
     }
 
     pub fn insert_batch_message(&mut self, sender_addr: Uint256, batch: &[u8]) {
-        self.insert_l2_message(sender_addr, batch, false);
+        self.insert_l2_message(sender_addr, batch);
     }
 
     pub fn _insert_nonmutating_call_message(
@@ -494,7 +534,7 @@ impl RuntimeEnvironment {
         buf.extend(to_addr.to_bytes_be());
         buf.extend_from_slice(data);
 
-        self.insert_l2_message(sender_addr, &buf, false);
+        self.insert_l2_message(sender_addr, &buf);
     }
 
     pub fn insert_eth_deposit_message(
@@ -514,13 +554,15 @@ impl RuntimeEnvironment {
         );
     }
 
-    pub fn get_and_incr_seq_num(&mut self, addr: &Uint256) -> Uint256 {
+    pub fn get_seq_num(&mut self, addr: &Uint256, do_increment: bool) -> Uint256 {
         let cur_seq_num = match self.caller_seq_nums.get(&addr) {
             Some(sn) => sn.clone(),
             None => Uint256::zero(),
         };
-        self.caller_seq_nums
-            .insert(addr.clone(), cur_seq_num.add(&Uint256::one()));
+        if do_increment {
+            self.caller_seq_nums
+                .insert(addr.clone(), cur_seq_num.add(&Uint256::one()));
+        }
         cur_seq_num
     }
 


### PR DESCRIPTION
Add tests of gas estimation functionality.  The tests do gas estimation through preferred aggregator and non-preferred aggregator, then runs the transaction again for real, with gas amount based on the estimate.