### PR TITLE
Better compiler defaults

### DIFF
--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -655,6 +655,15 @@ pub fn compile_from_folder(
     release_build: bool,
     builtins: bool,
 ) -> Result<Vec<CompiledProgram>, CompileError> {
+    let constants_default = folder.join("constants.json");
+    let constants_path = match constants_path {
+        Some(path) => Some(path),
+        None => match constants_default.exists() {
+            true => Some(constants_default.as_path()),
+            false => None,
+        },
+    };
+
     let (mut programs, import_map) = create_program_tree(
         folder,
         library,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,12 @@ fn main() -> Result<(), CompileError> {
                 .build_global()
                 .expect("failed to initialize rayon thread pool");
 
-            let mut output = get_output(compile.output.clone()).unwrap();
+            let mut output = match compile.output {
+                Some(ref path) => File::create(path)
+                    .map(|f| Box::new(f) as Box<dyn io::Write>)
+                    .unwrap(),
+                None => Box::new(io::sink()),
+            };
 
             let error_system = match compile.invoke() {
                 Ok((program, error_system)) => {


### PR DESCRIPTION
By default, `-o` now pipes to /dev/null
```
mini compile arb_os
mini compile arb_os -o /dev/null
```

By default, `-c` looks for a `constants.json` in the same directory
```
mini compile arb_os
mini compile arb_os -c arb_os/constants.json
```