### PR TITLE
No more beeps

### DIFF
--- a/builtin/arraytest.mini
+++ b/builtin/arraytest.mini
@@ -22,24 +22,24 @@ type opClosure = struct {
 
 
 write func main() {
-	asm(tests(),) { log };
+	asm(tests().1) { log };
 }
 
-func tests() -> uint {
+func tests() -> (uint, buffer) {
 	let a = newarray<any>(17);
 	if (a[6] != null) {
-		return 1;
+		return "new small array isn't blank";
 	}
 
 	a = newarray<uint>(71);
 	if (a[66] != 0) {
-		return 2;
+		return "new large array isn't blank";
 	}
 
 	a = newarray<uint>(64);
 	a = a with { [17] = 3 };
 	if (a[17] != 3) {
-		return 3;
+		return "array assignment doesn't work";
 	}
 
 	a = newarray<uint>(111);
@@ -47,7 +47,7 @@ func tests() -> uint {
 	a = a with { [99] = 4 };
 	a = a with { [42] = 5 };
 	if (a[42] != 5) {
-		return 4;
+		return "array overwrites don't work";
 	}
 
 	a = newarray<uint>(111);
@@ -55,7 +55,7 @@ func tests() -> uint {
 	a = a with { [99] = 4 };
 	a = a with { [42] = 5 };
 	if (a[99] != 4) {
-		return 5;
+		return "array overwrites corrupt other entries";
 	}
 
 	let a = newarray<uint>(17);
@@ -66,7 +66,7 @@ func tests() -> uint {
 		unsafecast<opClosure>(struct { f: addFunc, val: 4, })
 	);
 	if (result.1 != 7) {
-		return 6;
+		return "array closures don't work";
 	}
     
     let a = newarray<uint>(117);
@@ -77,62 +77,62 @@ func tests() -> uint {
     let a = unsafecast<array>(a);
     let pair = builtin_arrayGetConsecutive(a, 58);
     if (pair.0 != 32 || pair.1 != 64) {
-        return 7;
+        return "consecutive array access doesn't work";
     }
     if let Some(updated) = builtin_arraySetSafe(a, 63, 80) {
         a = updated;
     } else {
-        return 8;
+        return "array set safe doesn't work";
     }
-    if let Some(issue) = builtin_arraySetSafe(a, 117, 4) {
-        return 8;
+    if let Some(_issue) = builtin_arraySetSafe(a, 117, 4) {
+        return "array set safe went out of bounds";
     }
     let pair = builtin_arrayGetConsecutive(a, 63);
     if (pair.0 != 80 || pair.1 != 96) {
-        return 9;
+        return "consecutive array access didn't update";
     }
     
     if (builtin_arrayGetSafe(a, 116) == None<any>) {
-        return 10;
+        return "safe indexing thinks it's out of bounds";
     }
     if (builtin_arrayGetSafe(a, 117) != None<any>) {
-        return 10;
+        return "unsafe indexing thinks it's inbounds";
     }
     if (builtin_arrayGetConsecutiveSafe(a, 116) != None<(any, any)>) {
-        return 11;
+        return "unsafe consecutive indexing thinks it's inbounds";
     }
     if (builtin_arrayGetConsecutiveSafe(a, 62) == None<(any, any)>) {
-        return 11;
+        return "safe consecutive indexing thinks it's out of bounds";
     }
     
     a = array_resize(a, 117, 8);
     a = array_resize(a, 116, 8);
     let (a, old) = builtin_arraySwap(a, 63, 100);
     if (old != 80) {
-        return 12;
+        return "array swap doesn't work";
     }
     if let Some(change) = builtin_arraySwapSafe(a, 63, 102) {
         a = change.0;
         if (change.1 != 100) {
-            return 12;
+            return "array swap safe doesn't work";
         }
     } else {
-        return 12;
+        return "array swap safe didn't update";
     }
-    if let Some(issue) = builtin_arraySwapSafe(a, 116, 104) {
-        return 12;
+    if let Some(_issue) = builtin_arraySwapSafe(a, 116, 104) {
+        return "unsafe array swap thinks it's inbounds";
     }
     
-    if let Some(issue) = builtin_arrayOpSafe(a, 116, unsafecast<opClosure>(struct { f: addFunc, val: 8, })) {
-        return 13;
+    if let Some(_issue) = builtin_arrayOpSafe(a, 116, unsafecast<opClosure>(struct { f: addFunc, val: 8, })) {
+        return "unsafe closure corrupted the array";
     }
     if let Some(change) = builtin_arrayOpSafe(a, 63, unsafecast<opClosure>(struct { f: addFunc, val: 8, })) {
         a = change.0;
         if (change.1 != 110) {
-            return 13;
+            return "array closures don't work";
         }
     } else {
-        return 13;
+        return "safe array closure thinks something is wrong";
     }
     
     let (a, value_63, value_64) = 
@@ -144,7 +144,7 @@ func tests() -> uint {
         );
     
     if (value_63 != 126 || value_64 != 120) {
-        return 14;
+        return "consecutive array op miscomputes";
     }
     
     if let Some(change) = builtin_arrayOpConsecutiveSafe(
@@ -155,20 +155,20 @@ func tests() -> uint {
     ) {
         a = change.0;
         if (change.1 != 142 || change.2 != 144) {
-            return 15;
+            return "safe consecutive array op miscomputes";
         }
     }
     
-    if let Some(issue) = builtin_arrayOpConsecutiveSafe(
+    if let Some(_issue) = builtin_arrayOpConsecutiveSafe(
         a,
         115,
         unsafecast<opClosure>(struct { f: addFunc, val: 16, }),
         unsafecast<opClosure>(struct { f: addFunc, val: 24, })
     ) {
-        return 15;
+        return "unsafe consecutive array op thinks it's inbounds";
     }
     
-	return 0;
+    return "";
 }
 
 func addFunc(thunk: uint, oldVal: uint) -> (uint, uint) {

--- a/builtin/kvstest.mini
+++ b/builtin/kvstest.mini
@@ -12,36 +12,36 @@ use core::kvs::builtin_kvsForall;
 use core::kvs::builtin_kvsSize;
 
 write func main() {
-	asm(tests(),) { log };
+	asm(tests().1) { log };
 }
 
-func tests() -> uint {
+func tests() -> (uint, buffer) {
 	let s = builtin_kvsNew();
 	if (builtin_kvsGet(s, 17) != None<any>) {
-		return 1;
+		return "new map isn't empty";
 	}
     s = builtin_kvsDelete(s, 17);
 	if (builtin_kvsSize(s) != 0) {
-	    return 101;
+	    return "map delete doesn't preserve size";
 	}
 
 	s = builtin_kvsNew();
 	s = builtin_kvsSet(s, 42, 42);
 	if (builtin_kvsGet(s, 42) != Some(unsafecast<any>(42))) {
-		return 2;
+		return "map set-get doesn't work";
 	}
 	if (builtin_kvsSize(s) != 1) {
-	    return 102;
+	    return "map set doesn't increase size";
 	}
 	s = builtin_kvsNew();
 	s = builtin_kvsSet(s, 42, 43);
 	s = builtin_kvsSet(s, 55, 56);
 	s = builtin_kvsSet(s, 42, 99);
 	if (builtin_kvsGet(s, 42) != Some(unsafecast<any>(99))) {
-		return 3;
+		return "map overwrite doesn't work";
 	}
 	if (builtin_kvsSize(s) != 2) {
-	    return 103;
+	    return "map overwrite doesn't preserve size";
 	}
 
 	s = builtin_kvsNew();
@@ -49,10 +49,10 @@ func tests() -> uint {
 	s = builtin_kvsSet(s, 55, 56);
 	s = builtin_kvsSet(s, 42, 99);
 	if (builtin_kvsGet(s, 55) != Some(unsafecast<any>(56))) {
-		return 4;
+		return "map overwrite affects other keys";
 	}
 	if (builtin_kvsSize(s) != 2) {
-	    return 104;
+	    return "map overwrite doesn't preserve size";
 	}
 
 	s = builtin_kvsNew();
@@ -62,10 +62,10 @@ func tests() -> uint {
 		i = i+1;
 	}
 	if (builtin_kvsGet(s, 17) != Some(unsafecast<any>(1017))) {
-		return 5;
+		return "writing many times corrupted map";
 	}
 	if (builtin_kvsSize(s) != 41) {
-	    return 105;
+	    return "writing many times corrupted size";
 	}
 
 	s = builtin_kvsNew();
@@ -74,20 +74,20 @@ func tests() -> uint {
 		s = builtin_kvsSet(s, i, 1000+i);
 		i = i+1;
         if (!builtin_kvsHasKey(s, i-1)) {
-            return 6;
+            return "key existence check is wrong";
         }
 	}
 	s = builtin_kvsDelete(s, 17);
 	if (builtin_kvsGet(s, 17) != None<any>) {
-		return 6;
+		return "map deletion didn't remove value";
 	}
     if (builtin_kvsHasKey(s, 17)) {
-        return 6;
+        return "map deletion looks like it didn't remove value";
     }
     s = builtin_kvsDelete(s, 17);
     s = builtin_kvsDelete(s, 1000);
 	if (builtin_kvsSize(s) != 26) {
-	    return 106;
+	    return "map delete corrupts size";
 	}
 
 	s = builtin_kvsNew();
@@ -95,10 +95,10 @@ func tests() -> uint {
 	s = builtin_kvsSet(s, 55, 56);
 	s = builtin_kvsSet(s, 42, 99);
 	if (builtin_kvsGet(s, 42) != Some(unsafecast<any>(99))) {
-		return 7;
+		return "map overwrite doesn't work #2";
 	}
 	if (builtin_kvsSize(s) != 2) {
-	    return 107;
+	    return "map overwrite doesn't preserve size #2";
 	}
 
 	s = builtin_kvsNew();
@@ -106,10 +106,10 @@ func tests() -> uint {
 	s = builtin_kvsSet(s, 55, 56);
 	s = builtin_kvsSet(s, 42, 99);
 	if (builtin_kvsGet(s, 3) != None<any>) {
-		return 8;
+		return "map overwrite affects other entries";
 	}
 	if (builtin_kvsSize(s) != 2) {
-	    return 108;
+	    return "getting nonexistent value changed size after overwrite";
 	}
 
 	s = builtin_kvsNew();
@@ -118,10 +118,10 @@ func tests() -> uint {
 	s = builtin_kvsSet(s, 42, 99);
 	let rawResult = builtin_kvsForall(s, sumForKvsIterator, 0);
 	if (unsafecast<uint>(rawResult) != 155) {
-		return 9;
+		return "map forall did not compute correctly";
 	}
 	if (builtin_kvsSize(s) != 2) {
-	    return 109;
+	    return "map forall did not preserve size";
 	}
 
     // regression test for bug #73
@@ -132,29 +132,13 @@ func tests() -> uint {
     s = builtin_kvsSet(s, 55, 100);
     s = builtin_kvsDelete(s, 55);
     if (builtin_kvsGet(s, 55) != None<any>) {
-        return 10;
+        return "bug #73 is back (data)";
     }
 	if (builtin_kvsSize(s) != 0) {
-	    return 110;
+	    return "bug #73 is back (size)";
 	}
 
-	return 0;
-}
-
-func isSome(x: option<any>) -> bool {
-	return xif let Some(unused) = x {
-		true
-	} else {
-		false
-	};
-}
-
-func getSomeOr(x: option<any>, backupVal: any) -> any {
-	return xif let Some(val) = x {
-		val
-	} else {
-		backupVal
-	};
+	return "";
 }
 
 func sumForKvsIterator(_key: any, value: any, state: any) -> any {

--- a/builtin/maptest.mini
+++ b/builtin/maptest.mini
@@ -3,31 +3,31 @@
 //
 
 write func main() {
-	asm(tests(),) { log };
+	asm(tests().1) { log };
 }
 
-func tests() -> uint {
+func tests() -> (uint, buffer) {
 	let m = newmap<(uint, uint), uint>;
 	if (m[(17, 18,)] != None<uint>) {
-		return 1;
+		return "map<(uint, uint), uint> isn't empty";
 	}
 
 	let m = newmap<uint, uint>;
 	if (m[17] != None<uint>) {
-		return 2;
+		return "map<uint, uint> isn't empty";
 	}
 
 	let m = newmap<(uint, uint), uint>;
 	m = m with { [(999, 321,)] = 42 };
 	if ( m[(999, 321,)] != Some(42) ) { 
-		return 3;
+		return "map assignment is wrong";
 	}
 
 	m = newmap<(uint, uint), uint>;
 	m = m with { [(999, 321,)] = 42 };
 	m = m with { [(0, 0,)] = 73 };
 	if ( m[(999, 321,)] != Some(42) ) { 
-		return 4;
+		return "map assignment is inconsistent";
 	}
 
 	m = newmap<(uint, uint), uint>;
@@ -36,8 +36,8 @@ func tests() -> uint {
 	m = m with { [(999, 321,)] = 13 };
 	m = m with { [(0, 0,)] = 173 };
 	if (m[(999, 321,)] != Some(13) ){
-		return 5;
+		return "map update is incorrect";
 	}
 
-	return 0;
+	return "";
 }

--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -809,9 +809,16 @@ impl Value {
     pub fn pretty_print(&self, highlight: &str) -> String {
         match self {
             Value::Int(i) => Color::color(highlight, i),
-            Value::Buffer(_buf) => Color::lavender(self),
             Value::CodePoint(pc) => Color::color(highlight, pc),
             Value::Label(label) => Color::color(highlight, label),
+            Value::Buffer(buf) => {
+                let mut text = String::from_utf8_lossy(&hex::decode(buf.hex_encode()).unwrap())
+                    .chars()
+                    .filter(|c| !c.is_ascii_control())
+                    .collect::<String>();
+                text.truncate(100);
+                Color::lavender(format!("\"{}\"", text))
+            }
             Value::Tuple(tup) => match tup.is_empty() {
                 true => Color::grey("_"),
                 false => {
@@ -844,13 +851,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Value::Int(i) => i.fmt(f),
-            Value::Buffer(buf) => {
-                write!(
-                    f,
-                    "\"{}\"",
-                    String::from_utf8_lossy(&hex::decode(buf.hex_encode()).unwrap())
-                )
-            }
+            Value::Buffer(buf) => write!(f, "Buffer({})", buf.hex_encode()),
             Value::CodePoint(pc) => write!(f, "CodePoint({})", pc),
             Value::Label(label) => write!(f, "Label({})", label),
             Value::Tuple(tup) => {

--- a/src/minitests/mod.rs
+++ b/src/minitests/mod.rs
@@ -24,8 +24,14 @@ fn test_from_file_with_args_and_return(
     let res = run_from_file(path, args, coverage_filename, false);
     match res {
         Ok(res) => match &res[0] {
-            Value::Buffer(_) if res[0] != ret => panic!("{}", Color::red(&res[0])),
-            _ => assert_eq!(res[0], ret),
+            Value::Buffer(_) if res[0] != ret => panic!("{}", &res[0].pretty_print(Color::RED)),
+            _ => {
+                if res[0] != ret {
+                    println!("  - expected {}", ret.pretty_print(Color::RED));
+                    println!("  - executed {}", res[0].pretty_print(Color::RED));
+                    panic!("Unexpected result from test");
+                }
+            }
         },
         Err((error, trace)) => {
             println!("{}", error);
@@ -60,12 +66,12 @@ fn test_for_numeric_error_code(path: &Path) {
 
 #[test]
 fn test_arraytest() {
-    test_for_numeric_error_code(Path::new("builtin/arraytest.mexe"));
+    test_for_error_string(Path::new("builtin/arraytest.mexe"));
 }
 
 #[test]
 fn test_kvstest() {
-    test_for_numeric_error_code(Path::new("builtin/kvstest.mexe"));
+    test_for_error_string(Path::new("builtin/kvstest.mexe"));
 }
 
 #[test]
@@ -95,7 +101,7 @@ fn test_bytearray() {
 
 #[test]
 fn test_map() {
-    test_for_numeric_error_code(Path::new("builtin/maptest.mexe"));
+    test_for_error_string(Path::new("builtin/maptest.mexe"));
 }
 
 #[test]
@@ -105,7 +111,7 @@ fn test_keccak() {
 
 #[test]
 fn test_bls() {
-    test_for_numeric_error_code(Path::new("stdlib/blstest.mexe"));
+    test_for_error_string(Path::new("stdlib/blstest.mexe"));
 }
 
 #[test]

--- a/stdlib/blstest.mini
+++ b/stdlib/blstest.mini
@@ -10,10 +10,10 @@ use std::bls::bls_verifySingleSig;
 
 
 write func main() {
-	asm(tests(),) { log };
+	asm(tests().1) { log };
 }
 
-func tests() -> uint {
+func tests() -> (uint, buffer) {
     let domain2 = bytes32(0x2d889d03243d367c56457383bb04bcdadff3a522dbf9c97145d0a58c1e88d6f9);
 
     let message2 = bytearray_new(12);
@@ -48,17 +48,17 @@ func tests() -> uint {
     };
 
     if let Some(hashedmessage) = bls_hashToPoint(domain2, message2) {
-        if let Some(res) = bls_verifySingleSig(hashedmessage, pubkey, signature){
+        if let Some(_res) = bls_verifySingleSig(hashedmessage, pubkey, signature){
             // This is the expected case.
         } else {
-            return 5;
+            return "single sig is wrong";
         }
-        if let Some(res2) = bls_verifySingleSig(hashedmessage, pubkey, bad_signature){
-            return 6;
+        if let Some(_res2) = bls_verifySingleSig(hashedmessage, pubkey, bad_signature){
+            return "bad signature somehow checked-out";
         }
     } else {
-         return 7;
+         return "hash failed";
     }
 
-    return 0;   // passed all tests
+    return "";   // passed all tests
 }


### PR DESCRIPTION
- Makes pretty printing buffers as utf-8 exclude control characters
- Pretty printing is no longer the default for buffers for correctness reasons
-- you must call `pretty_print` on an `mavm:Value` to make nested buffers human-readable
- Adds string-based error codes to a few test files
- Adds prettier import error